### PR TITLE
fix: stabilize schema name resolution to avoid py comment drift

### DIFF
--- a/internal/openapi/openapi.go
+++ b/internal/openapi/openapi.go
@@ -417,8 +417,14 @@ func (d *Document) SchemaName(schema *Schema) (string, bool) {
 		return refName(schema.Ref, "#/components/schemas/")
 	}
 	if d != nil {
-		for name, candidate := range d.Components.Schemas {
-			if candidate == schema {
+		// Use sorted keys so aliased schema pointers resolve deterministically.
+		names := make([]string, 0, len(d.Components.Schemas))
+		for name := range d.Components.Schemas {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if d.Components.Schemas[name] == schema {
 				return name, true
 			}
 		}

--- a/internal/openapi/openapi_test.go
+++ b/internal/openapi/openapi_test.go
@@ -356,3 +356,26 @@ components:
 		t.Fatal("did not expect refName success for invalid ref")
 	}
 }
+
+func TestSchemaNameDeterministicForAliasedPointers(t *testing.T) {
+	shared := &Schema{Type: "object"}
+	doc := &Document{
+		Components: Components{
+			Schemas: map[string]*Schema{
+				"z_alias": shared,
+				"a_alias": shared,
+				"m_alias": shared,
+			},
+		},
+	}
+
+	for i := 0; i < 128; i++ {
+		name, ok := doc.SchemaName(shared)
+		if !ok {
+			t.Fatal("expected schema name for aliased pointer")
+		}
+		if name != "a_alias" {
+			t.Fatalf("expected deterministic lexical alias, got %q", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes a nondeterministic schema-name lookup path in OpenAPI resolution that could cause regenerated Python SDK comments/types to drift across runs in alias scenarios.

## What Changed

- Updated `Document.SchemaName` to iterate `components.schemas` with sorted keys before pointer matching.
- Added a regression test that verifies deterministic behavior when multiple schema names reference the same schema pointer.

## Why

`SchemaName` previously depended on Go map iteration order when resolving by pointer without `$ref`. In alias cases, this could pick different schema names across runs and ripple into generated output (including comments/docstrings/type references).

## Downstream PR

- coze-py: https://github.com/coze-dev/coze-py/pull/373

## Validation

- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (coverage: 83.0%)
- `./scripts/build.sh`
- Repeated Python generation runs produced stable hashes.
