### PR TITLE
feat: support POST /v1/enterprises/{enterprise_id}/organizations

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -2441,6 +2441,14 @@ api:
       source_dir: cozepy/enterprises
       path_prefixes:
         - /v1/enterprises
+    - name: enterprises_organizations
+      source_dir: cozepy/enterprises/organizations
+      client_class: EnterprisesOrganizationsClient
+      async_client_class: AsyncEnterprisesOrganizationsClient
+      empty_models:
+        - CreateEnterpriseOrganizationResp
+      path_prefixes:
+        - /v1/enterprises
     - name: enterprises_members
       source_dir: cozepy/enterprises/members
       client_class: EnterprisesMembersClient
@@ -5146,6 +5154,21 @@ api:
       stream_keyword: true
       response_type: CreateEnterpriseMemberResp
       response_cast: CreateEnterpriseMemberResp
+    - path: /v1/enterprises/{enterprise_id}/organizations
+      method: post
+      order: 86
+      sdk_methods:
+        - enterprises_organizations.create
+      body_builder: dump_exclude_none
+      body_fields:
+        - name
+        - super_admin_user_id
+        - description
+      body_required_fields:
+        - name
+        - super_admin_user_id
+      response_type: CreateEnterpriseOrganizationResp
+      response_cast: CreateEnterpriseOrganizationResp
     - path: /v1/enterprises/{enterprise_id}/members/{user_id}
       method: put
       order: 88
@@ -5491,8 +5514,6 @@ api:
       response_cast: User
       allow_missing_in_swagger: true
   ignore_apis:
-    - path: /v1/enterprises/{enterprise_id}/organizations
-      method: post
     - path: /v1/commerce/benefit/benefits/get
       method: get
     - path: /v1/commerce/benefit/bill_tasks


### PR DESCRIPTION
## Summary
- add package config for `enterprises_organizations` at `cozepy/enterprises/organizations`
- add operation mapping for `POST /v1/enterprises/{enterprise_id}/organizations` as `enterprises_organizations.create`
- remove this API from `ignore_apis`

## Behavior Changes
- generated Python SDK exposes:
  - `coze.enterprises.organizations.create(...)`
  - `async_coze.enterprises.organizations.create(...)`

## Generator/Config Changes
- `config/generator.yaml`
  - add `enterprises_organizations` package with response model `CreateEnterpriseOrganizationResp`
  - add operation mapping with required body fields `name` and `super_admin_user_id`

## Validation
- `./scripts/genpy.sh --output-sdk exist-repo/coze-py-generated --no-ci-check`
- `./scripts/gengo.sh --output-sdk exist-repo/coze-go-generated --no-ci-check`
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (coverage: 83.0%)
- `./scripts/build.sh`
