### PR TITLE
refactor: remove blank_line_before_return mapping switches

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4413,7 +4413,6 @@ api:
       order: 68
       sdk_methods:
         - bots.publish
-      blank_line_before_return: true
       force_multiline_signature_async: true
       body_builder: raw
       pre_body_code:
@@ -4720,7 +4719,6 @@ api:
       arg_types:
         name: str
         desc: str
-      blank_line_before_return: true
       force_multiline_signature: true
       response_type: CreateVoicePrintGroupResp
       response_cast: CreateVoicePrintGroupResp
@@ -4738,7 +4736,6 @@ api:
         group_id: str
         name: str
         desc: str
-      blank_line_before_return: true
       force_multiline_signature: true
       response_type: UpdateVoicePrintGroupResp
       response_cast: UpdateVoicePrintGroupResp
@@ -4812,7 +4809,6 @@ api:
         sample_rate: int
         channel: int
       files_before_body: true
-      blank_line_before_return: true
       force_multiline_signature: true
       response_type: SpeakerIdentifyResp
       response_cast: SpeakerIdentifyResp
@@ -4843,7 +4839,6 @@ api:
         sample_rate: int
         channel: int
       files_before_body: true
-      blank_line_before_return: true
       force_multiline_signature: true
       response_type: CreateVoicePrintGroupFeatureResp
       response_cast: CreateVoicePrintGroupFeatureResp
@@ -4871,7 +4866,6 @@ api:
         sample_rate: int
         channel: int
       files_before_body: true
-      blank_line_before_return: true
       force_multiline_signature: true
       response_type: UpdateVoicePrintGroupFeatureResp
       response_cast: UpdateVoicePrintGroupFeatureResp
@@ -4982,7 +4976,6 @@ api:
         text: str
         space_id: str
         description: str
-      blank_line_before_return: true
       response_type: Voice
       response_cast: Voice
     - path: /v1/conversation/message/create
@@ -5006,7 +4999,6 @@ api:
         content: str
         content_type: MessageContentType
         meta_data: Dict[str, str]
-      blank_line_before_return: true
       response_type: Message
       response_cast: Message
     - path: /v1/conversation/message/delete
@@ -5017,7 +5009,6 @@ api:
       query_builder: raw
       disable_request_body: true
       force_multiline_signature: true
-      blank_line_before_return: true
       response_type: Message
       response_cast: Message
     - path: /v1/conversation/message/modify
@@ -5035,7 +5026,6 @@ api:
         content: str
         content_type: MessageContentType
         meta_data: Dict[str, str]
-      blank_line_before_return: true
       response_type: Message
       response_cast: Message
       data_field: message
@@ -5047,7 +5037,6 @@ api:
       query_builder: raw
       disable_request_body: true
       force_multiline_signature: true
-      blank_line_before_return: true
       response_type: Message
       response_cast: Message
     - path: /v1/conversations/{conversation_id}/messages/{message_id}/feedback
@@ -5071,7 +5060,6 @@ api:
         - body
         - cast
         - headers
-      blank_line_before_return: true
       response_type: CreateConversationMessageFeedbackResp
       response_cast: CreateConversationMessageFeedbackResp
     - path: /v1/conversations/{conversation_id}/messages/{message_id}/feedback
@@ -5395,7 +5383,6 @@ api:
       no_blank_line_after_headers: true
       force_multiline_request_call: true
       stream_wrap_compact_async_return: true
-      stream_wrap_blank_line_before_return_async: true
       response_type: Stream[ChatEvent]
       async_response_type: AsyncIterator[ChatEvent]
       response_cast: None

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,7 +211,6 @@ type OperationMapping struct {
 	StreamWrapSyncResponseVar      string            `yaml:"stream_wrap_sync_response_var"`
 	StreamWrapCompactAsyncReturn   bool              `yaml:"stream_wrap_compact_async_return"`
 	StreamWrapCompactSyncReturn    bool              `yaml:"stream_wrap_compact_sync_return"`
-	StreamWrapBlankLineBeforeAsync bool              `yaml:"stream_wrap_blank_line_before_return_async"`
 	QueryBuilder                   string            `yaml:"query_builder"`
 	QueryBuilderSync               string            `yaml:"query_builder_sync"`
 	QueryBuilderAsync              string            `yaml:"query_builder_async"`
@@ -224,7 +223,6 @@ type OperationMapping struct {
 	BlankLineAfterHeaders          bool              `yaml:"blank_line_after_headers"`
 	NoBlankLineAfterHeaders        bool              `yaml:"no_blank_line_after_headers"`
 	BlankLineAfterDocstring        bool              `yaml:"blank_line_after_docstring"`
-	BlankLineBeforeReturn          bool              `yaml:"blank_line_before_return"`
 	ForceMultilineSignature        bool              `yaml:"force_multiline_signature"`
 	ForceMultilineSignatureSync    bool              `yaml:"force_multiline_signature_sync"`
 	ForceMultilineSignatureAsync   bool              `yaml:"force_multiline_signature_async"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -588,33 +588,6 @@ func TestRenderOperationMethodStreamWrapCompactAsyncReturn(t *testing.T) {
 	}
 }
 
-func TestRenderOperationMethodStreamWrapBlankLineBeforeAsyncReturn(t *testing.T) {
-	doc := mustParseSwagger(t)
-	details := openapi.OperationDetails{
-		Path:   "/v1/demo/stream",
-		Method: "post",
-	}
-	binding := pygen.OperationBinding{
-		PackageName: "demo",
-		MethodName:  "stream_call",
-		Details:     details,
-		Mapping: &config.OperationMapping{
-			RequestStream:                  true,
-			ResponseType:                   "Stream[DemoEvent]",
-			AsyncResponseType:              "AsyncIterator[DemoEvent]",
-			ResponseCast:                   "None",
-			StreamWrap:                     true,
-			StreamWrapCompactAsyncReturn:   true,
-			StreamWrapBlankLineBeforeAsync: true,
-		},
-	}
-
-	asyncCode := pygen.RenderOperationMethod(doc, binding, true)
-	if !strings.Contains(asyncCode, "resp: AsyncIteratorHTTPResponse[str] = await self._requester.arequest(\"post\", url, True, cast=None, headers=headers)\n\n        return AsyncStream(") {
-		t.Fatalf("expected a blank line before async stream return:\n%s", asyncCode)
-	}
-}
-
 func TestRenderOperationMethodHeadersExpr(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{

--- a/internal/generator/python/generator.go
+++ b/internal/generator/python/generator.go
@@ -3764,7 +3764,6 @@ func renderOperationMethodWithContext(
 	streamWrapSyncResponseVar := "response"
 	streamWrapCompactAsyncReturn := false
 	streamWrapCompactSyncReturn := false
-	streamWrapBlankLineBeforeAsyncReturn := false
 	bodyFieldValues := map[string]string{}
 	paramAliases := map[string]string{}
 	argTypes := map[string]string{}
@@ -3825,7 +3824,6 @@ func renderOperationMethodWithContext(
 		}
 		streamWrapCompactAsyncReturn = binding.Mapping.StreamWrapCompactAsyncReturn
 		streamWrapCompactSyncReturn = binding.Mapping.StreamWrapCompactSyncReturn
-		streamWrapBlankLineBeforeAsyncReturn = binding.Mapping.StreamWrapBlankLineBeforeAsync
 		bodyCallExprOverride = strings.TrimSpace(binding.Mapping.BodyCallExpr)
 		headersExpr = strings.TrimSpace(binding.Mapping.HeadersExpr)
 		if override := strings.TrimSpace(binding.Mapping.PaginationRequestArg); override != "" {
@@ -4878,9 +4876,6 @@ func renderOperationMethodWithContext(
 			forceMultilineRequestCall = true
 		}
 	}
-	if binding.Mapping != nil && binding.Mapping.BlankLineBeforeReturn {
-		EnsureTrailingNewlines(&buf, 2)
-	}
 	if binding.Mapping != nil && binding.Mapping.ResponseUnwrapListFirst {
 		buf.WriteString(fmt.Sprintf("        res = %s\n", requestExpr))
 		buf.WriteString("        data = res.data[0]\n")
@@ -4920,9 +4915,6 @@ func renderOperationMethodWithContext(
 				buf.WriteString("        ):\n")
 				buf.WriteString("            yield item\n")
 			} else {
-				if streamWrapBlankLineBeforeAsyncReturn {
-					buf.WriteString("\n")
-				}
 				if streamWrapCompactAsyncReturn {
 					asyncStreamArgs := []string{"resp.data"}
 					if len(fieldLiterals) > 0 {


### PR DESCRIPTION
## Summary
- remove `blank_line_before_return` and `stream_wrap_blank_line_before_return_async` from generator config schema
- remove related conditional branches in Python method rendering logic
- keep default behavior as no extra blank line before `return` (default false)
- delete the obsolete rendering test and clean corresponding yaml mapping entries

## Validation
- ./scripts/fmt.sh
- ./scripts/lint.sh
- ./scripts/test.sh
- ./scripts/build.sh

## Downstream
- coze-py PR: https://github.com/coze-dev/coze-py/pull/375
