### PR TITLE
refactor: remove query_builder sync/async override config

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -5307,8 +5307,6 @@ api:
       sdk_methods:
         - workflows_versions.list
       query_builder: dump_exclude_none
-      query_builder_sync: dump_exclude_none
-      query_builder_async: remove_none_values
       query_fields:
         - name: publish_status
           type: PublishStatus

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,8 +212,6 @@ type OperationMapping struct {
 	StreamWrapCompactAsyncReturn   bool              `yaml:"stream_wrap_compact_async_return"`
 	StreamWrapCompactSyncReturn    bool              `yaml:"stream_wrap_compact_sync_return"`
 	QueryBuilder                   string            `yaml:"query_builder"`
-	QueryBuilderSync               string            `yaml:"query_builder_sync"`
-	QueryBuilderAsync              string            `yaml:"query_builder_async"`
 	BodyCallExpr                   string            `yaml:"body_call_expr"`
 	BodyFieldValues                map[string]string `yaml:"body_field_values"`
 	HeadersExpr                    string            `yaml:"headers_expr"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1095,8 +1095,6 @@ func TestRenderOperationMethodPaginationQueryBuilderAndTokenOverrides(t *testing
 	}
 	mapping := &config.OperationMapping{
 		QueryBuilder:                "dump_exclude_none",
-		QueryBuilderSync:            "dump_exclude_none",
-		QueryBuilderAsync:           "remove_none_values",
 		Pagination:                  "token",
 		PaginationDataClass:         "_PrivateListWorkflowVersionData",
 		PaginationItemType:          "WorkflowVersionInfo",
@@ -1131,8 +1129,8 @@ func TestRenderOperationMethodPaginationQueryBuilderAndTokenOverrides(t *testing
 	if !strings.Contains(asyncCode, "amake_request(\n                \"get\",") {
 		t.Fatalf("expected custom pagination http method in async request:\n%s", asyncCode)
 	}
-	if !strings.Contains(asyncCode, "params=remove_none_values(") {
-		t.Fatalf("expected async query builder override:\n%s", asyncCode)
+	if !strings.Contains(asyncCode, "params=dump_exclude_none(") {
+		t.Fatalf("expected async query builder to follow query_builder:\n%s", asyncCode)
 	}
 	if !strings.Contains(asyncCode, "page_token=page_token or \"\"") {
 		t.Fatalf("expected custom pagination token init expr in async code:\n%s", asyncCode)

--- a/internal/generator/python/generator.go
+++ b/internal/generator/python/generator.go
@@ -823,16 +823,8 @@ func RenderPackageModuleWithComments(
 			}
 			queryBuilder := "dump_exclude_none"
 			bodyBuilder := "dump_exclude_none"
-			queryBuilderSync := ""
-			queryBuilderAsync := ""
 			if binding.Mapping != nil {
 				queryBuilder = normalizeMapBuilder(binding.Mapping.QueryBuilder)
-				if override := strings.TrimSpace(binding.Mapping.QueryBuilderSync); override != "" {
-					queryBuilderSync = normalizeMapBuilder(override)
-				}
-				if override := strings.TrimSpace(binding.Mapping.QueryBuilderAsync); override != "" {
-					queryBuilderAsync = normalizeMapBuilder(override)
-				}
 				bodyBuilder = normalizeMapBuilder(binding.Mapping.BodyBuilder)
 			}
 			hasQueryFields := len(binding.Details.QueryParameters) > 0
@@ -840,29 +832,12 @@ func RenderPackageModuleWithComments(
 				hasQueryFields = true
 			}
 			hasBodyMap := binding.Mapping != nil && (len(binding.Mapping.BodyFields) > 0 || len(binding.Mapping.BodyFixedValues) > 0)
-			if hasQueryFields {
-				builders := make([]string, 0, 2)
-				if mappingGeneratesSync(binding.Mapping) {
-					if queryBuilderSync != "" {
-						builders = append(builders, queryBuilderSync)
-					} else {
-						builders = append(builders, queryBuilder)
-					}
+			if hasQueryFields && (mappingGeneratesSync(binding.Mapping) || mappingGeneratesAsync(binding.Mapping)) {
+				if queryBuilder == "dump_exclude_none" {
+					needDumpExcludeNone = true
 				}
-				if mappingGeneratesAsync(binding.Mapping) {
-					if queryBuilderAsync != "" {
-						builders = append(builders, queryBuilderAsync)
-					} else {
-						builders = append(builders, queryBuilder)
-					}
-				}
-				for _, builder := range builders {
-					if builder == "dump_exclude_none" {
-						needDumpExcludeNone = true
-					}
-					if builder == "remove_none_values" {
-						needRemoveNoneValues = true
-					}
+				if queryBuilder == "remove_none_values" {
+					needRemoveNoneValues = true
 				}
 			}
 			if hasBodyMap && (mappingGeneratesSync(binding.Mapping) || mappingGeneratesAsync(binding.Mapping)) {

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -479,15 +479,6 @@ func renderOperationMethodWithContext(
 		dataField = strings.TrimSpace(binding.Mapping.DataField)
 		requestStream = binding.Mapping.RequestStream
 		queryBuilder = normalizeMapBuilder(binding.Mapping.QueryBuilder)
-		if async {
-			if override := strings.TrimSpace(binding.Mapping.QueryBuilderAsync); override != "" {
-				queryBuilder = normalizeMapBuilder(override)
-			}
-		} else {
-			if override := strings.TrimSpace(binding.Mapping.QueryBuilderSync); override != "" {
-				queryBuilder = normalizeMapBuilder(override)
-			}
-		}
 		bodyBuilder = normalizeMapBuilder(binding.Mapping.BodyBuilder)
 		bodyAnnotation = strings.TrimSpace(binding.Mapping.BodyAnnotation)
 		compactSingleItemMaps = binding.Mapping.CompactSingleItemMaps


### PR DESCRIPTION
## Summary
- remove `query_builder_sync` and `query_builder_async` from generator config model
- remove generator logic that branches query builder by sync/async method generation
- remove the only YAML usage of `query_builder_sync/query_builder_async`
- keep one unified default behavior: both sync and async methods use `query_builder` (default remains `dump_exclude_none` when unset)

## Why
`query_builder_sync/query_builder_async` were compatibility-only overrides for historical hand-written differences. This PR simplifies config surface and makes query param builder behavior consistent across sync/async generation.

## Downstream PR
- https://github.com/coze-dev/coze-py/pull/376

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (coverage 83.0%)
- `./scripts/build.sh`
- `./scripts/gengo.sh --output-sdk exist-repo/coze-go-generated --no-ci-check`
- `./scripts/genpy.sh --output-sdk exist-repo/coze-py-generated --no-ci-check`
