### PR TITLE
feat(py): expose bots.collaboration_modes.update from ignore_apis

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -581,6 +581,14 @@ api:
         - schema: PublishStatus
           name: PublishStatus
           enum_base: dynamic_str
+        - name: BotCollaborationMode
+          allow_missing_in_swagger: true
+          enum_base: dynamic_str
+          enum_values:
+            - name: SINGLE
+              value: single
+            - name: COLLABORATION
+              value: collaboration
         - schema: PromptInfo
           name: BotPromptInfo
           required_fields:
@@ -915,6 +923,7 @@ api:
       empty_models:
         - UpdateBotResp
         - UnpublishBotResp
+        - SwitchBotCollaborationModeResp
       top_level_code:
         - |
           class _PrivateListBotsDataV1(CozeModel, NumberPagedResponse[SimpleBot]):
@@ -4526,6 +4535,20 @@ api:
       pagination_total_field: total
       pagination_page_num_field: page_index
       pagination_page_size_field: page_size
+    - path: /v1/bots/{bot_id}/collaboration_mode
+      method: post
+      order: 731
+      sdk_methods:
+        - bots.switch_collaboration_mode
+      body_builder: raw
+      body_fields:
+        - collaboration_mode
+      body_required_fields:
+        - collaboration_mode
+      arg_types:
+        collaboration_mode: BotCollaborationMode
+      response_type: SwitchBotCollaborationModeResp
+      response_cast: SwitchBotCollaborationModeResp
     - path: /v1/folders/{folder_id}
       method: get
       order: 74
@@ -5510,8 +5533,6 @@ api:
     - path: /v1/conversation/message/list
       method: post
     - path: /v3/chat/submit_tool_outputs
-      method: post
-    - path: /v1/bots/{bot_id}/collaboration_mode
       method: post
     - path: /v1/bots/{bot_id}/collaborators
       method: post

--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -572,6 +572,11 @@ api:
         - /v1/audio/voices
     - name: bots
       source_dir: cozepy/bots
+      child_clients:
+        - attribute: collaboration_modes
+          module: .collaboration_modes
+          sync_class: BotsCollaborationModesClient
+          async_class: AsyncBotsCollaborationModesClient
       extra_imports:
         - module: pydantic
           names:
@@ -581,14 +586,6 @@ api:
         - schema: PublishStatus
           name: PublishStatus
           enum_base: dynamic_str
-        - name: BotCollaborationMode
-          allow_missing_in_swagger: true
-          enum_base: dynamic_str
-          enum_values:
-            - name: SINGLE
-              value: single
-            - name: COLLABORATION
-              value: collaboration
         - schema: PromptInfo
           name: BotPromptInfo
           required_fields:
@@ -923,7 +920,6 @@ api:
       empty_models:
         - UpdateBotResp
         - UnpublishBotResp
-        - SwitchBotCollaborationModeResp
       top_level_code:
         - |
           class _PrivateListBotsDataV1(CozeModel, NumberPagedResponse[SimpleBot]):
@@ -1039,6 +1035,23 @@ api:
       path_prefixes:
         - /v1/bot
         - /v1/bots
+    - name: bots_collaboration_modes
+      source_dir: cozepy/bots/collaboration_modes
+      client_class: BotsCollaborationModesClient
+      async_client_class: AsyncBotsCollaborationModesClient
+      model_schemas:
+        - name: BotCollaborationMode
+          allow_missing_in_swagger: true
+          enum_base: dynamic_str
+          enum_values:
+            - name: SINGLE
+              value: single
+            - name: COLLABORATION
+              value: collaboration
+      empty_models:
+        - UpdateBotCollaborationModeResp
+      path_prefixes:
+        - /v1/bots/{bot_id}/collaboration_mode
     - name: chat
       source_dir: cozepy/chat
       separate_commented_enum_members: true
@@ -4539,7 +4552,7 @@ api:
       method: post
       order: 731
       sdk_methods:
-        - bots.switch_collaboration_mode
+        - bots_collaboration_modes.update
       body_builder: raw
       body_fields:
         - collaboration_mode
@@ -4547,8 +4560,8 @@ api:
         - collaboration_mode
       arg_types:
         collaboration_mode: BotCollaborationMode
-      response_type: SwitchBotCollaborationModeResp
-      response_cast: SwitchBotCollaborationModeResp
+      response_type: UpdateBotCollaborationModeResp
+      response_cast: UpdateBotCollaborationModeResp
     - path: /v1/folders/{folder_id}
       method: get
       order: 74


### PR DESCRIPTION
## Summary
Implement one ignored API in Python SDK generation: `POST /v1/bots/{bot_id}/collaboration_mode`.

This PR now exposes it as nested style:
- `coze.bots.collaboration_modes.update(...)`

## Changes
- Add `bots` child client:
  - attribute: `collaboration_modes`
  - module: `.collaboration_modes`
- Add new package `bots_collaboration_modes` (`cozepy/bots/collaboration_modes`).
- Add `BotCollaborationMode` enum in collaboration modes module.
- Add `UpdateBotCollaborationModeResp` empty response model.
- Map operation:
  - path: `/v1/bots/{bot_id}/collaboration_mode`
  - sdk method: `bots_collaboration_modes.update`
- Remove this API from `ignore_apis` (already done in this PR branch history).

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (total coverage: 83.0%)
- `./scripts/build.sh`
