### PR TITLE
feat(py): add bots.collaborators.delete from ignore_apis

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -1065,6 +1065,7 @@ api:
           name: BotCollaborator
       empty_models:
         - AddBotCollaboratorResp
+        - RemoveBotCollaboratorResp
       path_prefixes:
         - /v1/bots/{bot_id}/collaborators
     - name: chat
@@ -4594,6 +4595,14 @@ api:
         collaborators: List[BotCollaborator]
       response_type: AddBotCollaboratorResp
       response_cast: AddBotCollaboratorResp
+    - path: /v1/bots/{bot_id}/collaborators/{user_id}
+      method: delete
+      order: 733
+      sdk_methods:
+        - bots_collaborators.delete
+      disable_request_body: true
+      response_type: RemoveBotCollaboratorResp
+      response_cast: RemoveBotCollaboratorResp
     - path: /v1/folders/{folder_id}
       method: get
       order: 74
@@ -5577,8 +5586,6 @@ api:
       method: post
     - path: /v3/chat/submit_tool_outputs
       method: post
-    - path: /v1/bots/{bot_id}/collaborators/{user_id}
-      method: delete
     - path: /v1/bots/{bot_id}/versions
       method: get
   field_aliases:

--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -1065,7 +1065,7 @@ api:
           name: BotCollaborator
       empty_models:
         - AddBotCollaboratorResp
-        - RemoveBotCollaboratorResp
+        - DeleteBotCollaboratorResp
       path_prefixes:
         - /v1/bots/{bot_id}/collaborators
     - name: chat
@@ -4601,8 +4601,8 @@ api:
       sdk_methods:
         - bots_collaborators.delete
       disable_request_body: true
-      response_type: RemoveBotCollaboratorResp
-      response_cast: RemoveBotCollaboratorResp
+      response_type: DeleteBotCollaboratorResp
+      response_cast: DeleteBotCollaboratorResp
     - path: /v1/folders/{folder_id}
       method: get
       order: 74


### PR DESCRIPTION
## Summary
Implement one API from `ignore_apis` in Python SDK generation:
- `DELETE /v1/bots/{bot_id}/collaborators/{user_id}`

Exposed SDK style:
- `coze.bots.collaborators.delete(...)`

## Changes
- Extend `bots_collaborators` package:
  - add `RemoveBotCollaboratorResp` empty response model
- Add operation mapping:
  - path: `/v1/bots/{bot_id}/collaborators/{user_id}`
  - sdk method: `bots_collaborators.delete`
  - `disable_request_body: true`
- Remove this endpoint from `ignore_apis`.

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (total coverage: 83.0%)
- `./scripts/build.sh`

## Naming
- Rename response model to `DeleteBotCollaboratorResp` (from `RemoveBotCollaboratorResp`).