### PR TITLE
refactor: remove separate_commented_enum_members config

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -1069,7 +1069,6 @@ api:
         - /v1/bots/{bot_id}/collaborators
     - name: chat
       source_dir: cozepy/chat
-      separate_commented_enum_members: true
       model_schemas:
         - name: MessageRole
           allow_missing_in_swagger: true
@@ -2179,7 +2178,6 @@ api:
         - name: DocumentFormatType
           allow_missing_in_swagger: true
           enum_base: int
-          separate_commented_enum_members: true
           enum_values:
             - name: DOCUMENT
               value: 0
@@ -2214,7 +2212,6 @@ api:
         - name: DocumentStatus
           allow_missing_in_swagger: true
           enum_base: int
-          separate_commented_enum_members: true
           enum_values:
             - name: PROCESSING
               value: 0
@@ -2225,7 +2222,6 @@ api:
         - name: DocumentUpdateType
           allow_missing_in_swagger: true
           enum_base: int
-          separate_commented_enum_members: true
           enum_values:
             - name: NO_AUTO_UPDATE
               value: 0
@@ -3066,7 +3062,6 @@ api:
     - name: workflows_runs
       source_dir: cozepy/workflows/runs
       separate_commented_fields: true
-      separate_commented_enum_members: true
       client_class: WorkflowsRunsClient
       async_client_class: AsyncWorkflowsRunsClient
       model_schemas:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,7 +74,6 @@ type Package struct {
 	PathPrefixes              []string      `yaml:"path_prefixes"`
 	AllowMissingInSwagger     bool          `yaml:"allow_missing_in_swagger"`
 	DisableAutoImports        bool          `yaml:"disable_auto_imports"`
-	SeparateCommentedEnum     bool          `yaml:"separate_commented_enum_members"`
 	HTTPRequestFromModel      bool          `yaml:"http_request_from_model"`
 	ClientClass               string        `yaml:"client_class"`
 	AsyncClientClass          string        `yaml:"async_client_class"`
@@ -103,7 +102,6 @@ type ModelSchema struct {
 	PrependCode            []string          `yaml:"prepend_code"`
 	Builders               []ModelBuilder    `yaml:"builders"`
 	BeforeValidators       []ModelValidator  `yaml:"before_validators"`
-	SeparateCommentedEnum  *bool             `yaml:"separate_commented_enum_members"`
 	FieldOrder             []string          `yaml:"field_order"`
 	RequiredFields         []string          `yaml:"required_fields"`
 	FieldTypes             map[string]string `yaml:"field_types"`


### PR DESCRIPTION
## Summary
- remove `separate_commented_enum_members` from `config/generator.yaml`
- remove corresponding config schema fields from `internal/config/config.go`
- remove enum-render branching logic in Python model renderer and keep a single default behavior (compact enum member layout without extra blank lines)

## Generator impact
- this changes only enum comment spacing style for affected generated Python enums
- no OpenAPI mapping or method signature changes

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh`
- `./scripts/build.sh`
- `./scripts/genpy.sh --output-sdk /data00/home/chenyunpeng.1024/code/github/coze-dev/coze-sdk-gen-1/exist-repo/coze-py --ci-check`
- `./scripts/genpy.sh`
- `diff -ru ... exist-repo/coze-py exist-repo/coze-py-generated` (with cache/build artifacts excluded)

## Downstream PR
- coze-py PR: https://github.com/coze-dev/coze-py/pull/380
