### PR TITLE
feat: remove request_call_arg_order config override

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -5127,10 +5127,6 @@ api:
         feedback_type: FeedbackType
         reason_types: List[str]
         comment: str
-      request_call_arg_order:
-        - body
-        - cast
-        - headers
       response_type: CreateConversationMessageFeedbackResp
       response_cast: CreateConversationMessageFeedbackResp
     - path: /v1/conversations/{conversation_id}/messages/{message_id}/feedback
@@ -5183,10 +5179,6 @@ api:
         - caption
       arg_types:
         caption: str
-      request_call_arg_order:
-        - cast
-        - headers
-        - body
       response_type: UpdateImageRes
       response_cast: UpdateImageRes
     - path: /v1/enterprises/{enterprise_id}/members
@@ -5459,11 +5451,6 @@ api:
       stream_wrap_fields:
         - event
         - data
-      request_call_arg_order:
-        - stream
-        - cast
-        - headers
-        - body
       no_blank_line_after_headers: true
       force_multiline_request_call: true
       stream_wrap_compact_async_return: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -225,7 +225,6 @@ type OperationMapping struct {
 	ForceMultilineRequestCall      bool              `yaml:"force_multiline_request_call"`
 	ForceMultilineRequestCallSync  bool              `yaml:"force_multiline_request_call_sync"`
 	ForceMultilineRequestCallAsync bool              `yaml:"force_multiline_request_call_async"`
-	RequestCallArgOrder            []string          `yaml:"request_call_arg_order"`
 	PaginationHTTPMethod           string            `yaml:"pagination_http_method"`
 	PaginationRequestArg           string            `yaml:"pagination_request_arg"`
 	PaginationInitPageTokenExpr    string            `yaml:"pagination_init_page_token_expr"`
@@ -598,13 +597,6 @@ func (c *Config) Validate() error {
 		}
 		if mapping.StreamWrap && !mapping.RequestStream {
 			return fmt.Errorf("api.operation_mappings[%d].stream_wrap requires request_stream=true", i)
-		}
-		for j, argName := range mapping.RequestCallArgOrder {
-			switch strings.TrimSpace(argName) {
-			case "stream", "cast", "params", "headers", "body", "files", "data_field":
-			default:
-				return fmt.Errorf("api.operation_mappings[%d].request_call_arg_order[%d] must be one of: stream, cast, params, headers, body, files, data_field", i, j)
-			}
 		}
 		switch strings.TrimSpace(mapping.QueryBuilder) {
 		case "", "dump_exclude_none", "remove_none_values", "raw":

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -1396,9 +1396,7 @@ func renderOperationMethodWithContext(
 		"url",
 	}
 	type requestCallArg struct {
-		Key  string
 		Expr string
-		Pos  bool
 	}
 	optionalArgs := make([]requestCallArg, 0, 8)
 	streamLiteral := "False"
@@ -1409,15 +1407,15 @@ func renderOperationMethodWithContext(
 	if streamKeyword {
 		streamExpr = fmt.Sprintf("stream=%s", streamLiteral)
 	}
-	optionalArgs = append(optionalArgs, requestCallArg{Key: "stream", Expr: streamExpr, Pos: !streamKeyword})
+	optionalArgs = append(optionalArgs, requestCallArg{Expr: streamExpr})
 	castExprValue := fmt.Sprintf("cast=%s", castExpr)
-	optionalArgs = append(optionalArgs, requestCallArg{Key: "cast", Expr: castExprValue, Pos: false})
+	optionalArgs = append(optionalArgs, requestCallArg{Expr: castExprValue})
 	if len(queryFields) > 0 {
-		optionalArgs = append(optionalArgs, requestCallArg{Key: "params", Expr: "params=params"})
+		optionalArgs = append(optionalArgs, requestCallArg{Expr: "params=params"})
 	}
 	hasHeadersArg := true
 	if hasHeadersArg {
-		optionalArgs = append(optionalArgs, requestCallArg{Key: "headers", Expr: "headers=headers"})
+		optionalArgs = append(optionalArgs, requestCallArg{Expr: "headers=headers"})
 	}
 	if bodyArgExpr != "" {
 		bodyExpr := bodyArgExpr
@@ -1428,65 +1426,16 @@ func renderOperationMethodWithContext(
 				bodyExpr = bodyCallExprOverride
 			}
 		}
-		optionalArgs = append(optionalArgs, requestCallArg{Key: "body", Expr: fmt.Sprintf("body=%s", bodyExpr)})
+		optionalArgs = append(optionalArgs, requestCallArg{Expr: fmt.Sprintf("body=%s", bodyExpr)})
 	}
 	if filesExpr != "" || len(filesFieldNames) > 0 {
-		optionalArgs = append(optionalArgs, requestCallArg{Key: "files", Expr: "files=files"})
+		optionalArgs = append(optionalArgs, requestCallArg{Expr: "files=files"})
 	}
 	if dataField != "" {
-		optionalArgs = append(optionalArgs, requestCallArg{Key: "data_field", Expr: fmt.Sprintf("data_field=%q", dataField)})
+		optionalArgs = append(optionalArgs, requestCallArg{Expr: fmt.Sprintf("data_field=%q", dataField)})
 	}
-	if binding.Mapping != nil && len(binding.Mapping.RequestCallArgOrder) > 0 {
-		argByKey := map[string]requestCallArg{}
-		defaultOrder := make([]string, 0, len(optionalArgs))
-		for _, item := range optionalArgs {
-			if _, exists := argByKey[item.Key]; exists {
-				continue
-			}
-			argByKey[item.Key] = item
-			defaultOrder = append(defaultOrder, item.Key)
-		}
-		orderedKeys := make([]string, 0, len(optionalArgs))
-		seen := map[string]struct{}{}
-		for _, rawKey := range binding.Mapping.RequestCallArgOrder {
-			key := strings.TrimSpace(rawKey)
-			if key == "" {
-				continue
-			}
-			if _, exists := argByKey[key]; !exists {
-				continue
-			}
-			if _, exists := seen[key]; exists {
-				continue
-			}
-			orderedKeys = append(orderedKeys, key)
-			seen[key] = struct{}{}
-		}
-		for _, key := range defaultOrder {
-			if _, exists := seen[key]; exists {
-				continue
-			}
-			orderedKeys = append(orderedKeys, key)
-			seen[key] = struct{}{}
-		}
-		orderedItems := make([]requestCallArg, 0, len(orderedKeys))
-		for _, key := range orderedKeys {
-			orderedItems = append(orderedItems, argByKey[key])
-		}
-		for _, item := range orderedItems {
-			if item.Pos {
-				callArgs = append(callArgs, item.Expr)
-			}
-		}
-		for _, item := range orderedItems {
-			if !item.Pos {
-				callArgs = append(callArgs, item.Expr)
-			}
-		}
-	} else {
-		for _, item := range optionalArgs {
-			callArgs = append(callArgs, item.Expr)
-		}
+	for _, item := range optionalArgs {
+		callArgs = append(callArgs, item.Expr)
 	}
 	requestExpr := fmt.Sprintf("%s(%s)", requestCall, strings.Join(callArgs, ", "))
 	forceMultilineRequestCall := binding.Mapping != nil && binding.Mapping.ForceMultilineRequestCall


### PR DESCRIPTION
## Summary
- remove `request_call_arg_order` from operation mapping config and validation
- remove all `request_call_arg_order` entries from `config/generator.yaml`
- use a single default request call arg order in Python generator: `stream/cast/params/headers/body/files/data_field`
- add an end-to-end generator test to lock the default order behavior

## Downstream Python SDK PR
- https://github.com/coze-dev/coze-py/pull/381

## Validation
- ./scripts/fmt.sh
- ./scripts/lint.sh
- ./scripts/test.sh
- ./scripts/build.sh
- ./scripts/genpy.sh --output-sdk exist-repo/coze-py --ci-check
