### PR TITLE
feat(py): add bill_tasks.list from ignore_apis

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -1821,8 +1821,8 @@ api:
       async_client_class: AsyncChatMessagesClient
       path_prefixes:
         - /v3/chat/message
-    - name: commerce_benefit
-      source_dir: cozepy/commerce_benefit
+    - name: bill_tasks
+      source_dir: cozepy/bill_tasks
       allow_missing_in_swagger: true
       model_schemas:
         - schema: properties_data_properties_task_infos_items
@@ -1842,7 +1842,7 @@ api:
       override_pagination_classes:
         - _PrivateListBenefitBillTasksData
       path_prefixes:
-        - /v1/commerce/benefit
+        - /v1/commerce/benefit/bill_tasks
     - name: connectors
       source_dir: cozepy/connectors
       model_schemas:
@@ -3778,7 +3778,7 @@ api:
       method: get
       order: 735
       sdk_methods:
-        - commerce_benefit.list_bill_tasks
+        - bill_tasks.list
       query_builder: remove_none_values
       query_fields:
         - name: task_ids

--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -1821,6 +1821,28 @@ api:
       async_client_class: AsyncChatMessagesClient
       path_prefixes:
         - /v3/chat/message
+    - name: commerce_benefit
+      source_dir: cozepy/commerce_benefit
+      allow_missing_in_swagger: true
+      model_schemas:
+        - schema: properties_data_properties_task_infos_items
+          name: BenefitBillTask
+        - name: _PrivateListBenefitBillTasksData
+          allow_missing_in_swagger: true
+          base_classes:
+            - CozeModel
+            - NumberPagedResponse[BenefitBillTask]
+          extra_fields:
+            - name: task_infos
+              type: List[BenefitBillTask]
+              required: true
+            - name: total
+              type: int
+              required: true
+      override_pagination_classes:
+        - _PrivateListBenefitBillTasksData
+      path_prefixes:
+        - /v1/commerce/benefit
     - name: connectors
       source_dir: cozepy/connectors
       model_schemas:
@@ -3752,6 +3774,33 @@ api:
         - chat_id
       response_type: Chat
       response_cast: Chat
+    - path: /v1/commerce/benefit/bill_tasks
+      method: get
+      order: 735
+      sdk_methods:
+        - commerce_benefit.list_bill_tasks
+      query_builder: remove_none_values
+      query_fields:
+        - name: task_ids
+          type: List[str]
+          required: false
+        - name: page_num
+          type: int
+          required: true
+          default: "1"
+        - name: page_size
+          type: int
+          required: true
+          default: "20"
+      query_field_values:
+        task_ids: '",".join(task_ids) if task_ids else None'
+      pagination: number
+      pagination_data_class: _PrivateListBenefitBillTasksData
+      pagination_item_type: BenefitBillTask
+      pagination_items_field: task_infos
+      pagination_total_field: total
+      pagination_page_num_field: page_num
+      pagination_page_size_field: page_size
     - path: /v1/api_apps
       method: post
       order: 10
@@ -5640,8 +5689,6 @@ api:
       allow_missing_in_swagger: true
   ignore_apis:
     - path: /v1/commerce/benefit/benefits/get
-      method: get
-    - path: /v1/commerce/benefit/bill_tasks
       method: get
     - path: /v1/commerce/benefit/limitations
       method: post


### PR DESCRIPTION
## Summary
- implement one ignored API in codegen: `GET /v1/commerce/benefit/bill_tasks`
- add new python package config `commerce_benefit` with `BenefitBillTask` model and number-pagination data wrapper
- add operation mapping `commerce_benefit.list_bill_tasks` and remove this API from `ignore_apis`

## Generator Changes
- `config/generator.yaml`
  - add `commerce_benefit` package (`cozepy/commerce_benefit`)
  - add operation mapping for `commerce_benefit.list_bill_tasks`
  - remove `/v1/commerce/benefit/bill_tasks` from `ignore_apis`

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh`
- `./scripts/build.sh`
- `./scripts/genpy.sh --output-sdk /data00/home/chenyunpeng.1024/code/github/coze-dev/coze-sdk-gen-4/exist-repo/coze-py --ci-check`
