### PR TITLE
refactor: remove force_multiline_request_call_sync option

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4482,7 +4482,6 @@ api:
       order: 67
       sdk_methods:
         - bots.update
-      force_multiline_request_call_sync: true
       body_fields:
         - bot_id
         - name

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -223,7 +223,6 @@ type OperationMapping struct {
 	ForceMultilineSignatureSync    bool              `yaml:"force_multiline_signature_sync"`
 	ForceMultilineSignatureAsync   bool              `yaml:"force_multiline_signature_async"`
 	ForceMultilineRequestCall      bool              `yaml:"force_multiline_request_call"`
-	ForceMultilineRequestCallSync  bool              `yaml:"force_multiline_request_call_sync"`
 	ForceMultilineRequestCallAsync bool              `yaml:"force_multiline_request_call_async"`
 	PaginationHTTPMethod           string            `yaml:"pagination_http_method"`
 	PaginationRequestArg           string            `yaml:"pagination_request_arg"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -524,17 +524,16 @@ func TestRenderOperationMethodStreamWrapYieldAndSyncVarOverride(t *testing.T) {
 		MethodName:  "stream_call",
 		Details:     details,
 		Mapping: &config.OperationMapping{
-			RequestStream:                 true,
-			ResponseType:                  "Stream[DemoEvent]",
-			AsyncResponseType:             "AsyncIterator[DemoEvent]",
-			ResponseCast:                  "None",
-			StreamWrap:                    true,
-			StreamWrapHandler:             "handle_demo",
-			StreamWrapFields:              []string{"event", "data"},
-			StreamWrapAsyncYield:          true,
-			StreamWrapSyncResponseVar:     "resp",
-			ForceMultilineRequestCall:     false,
-			ForceMultilineRequestCallSync: false,
+			RequestStream:             true,
+			ResponseType:              "Stream[DemoEvent]",
+			AsyncResponseType:         "AsyncIterator[DemoEvent]",
+			ResponseCast:              "None",
+			StreamWrap:                true,
+			StreamWrapHandler:         "handle_demo",
+			StreamWrapFields:          []string{"event", "data"},
+			StreamWrapAsyncYield:      true,
+			StreamWrapSyncResponseVar: "resp",
+			ForceMultilineRequestCall: false,
 		},
 	}
 
@@ -585,6 +584,40 @@ func TestRenderOperationMethodStreamWrapCompactAsyncReturn(t *testing.T) {
 	asyncCode := pygen.RenderOperationMethod(doc, binding, true)
 	if !strings.Contains(asyncCode, "return AsyncStream(resp.data, fields=[\"event\", \"data\"], handler=handle_demo, raw_response=resp._raw_response)") {
 		t.Fatalf("expected compact async stream return line:\n%s", asyncCode)
+	}
+}
+
+func TestRenderOperationMethodForceMultilineRequestCallAsyncOnly(t *testing.T) {
+	doc := mustParseSwagger(t)
+	details := openapi.OperationDetails{
+		Path:   "/v1/demo",
+		Method: "post",
+		RequestBodySchema: &openapi.Schema{
+			Type: "object",
+			Properties: map[string]*openapi.Schema{
+				"name": {Type: "string"},
+			},
+		},
+	}
+	binding := pygen.OperationBinding{
+		PackageName: "demo",
+		MethodName:  "create",
+		Details:     details,
+		Mapping: &config.OperationMapping{
+			BodyFields:                     []string{"name"},
+			BodyRequiredFields:             []string{"name"},
+			ForceMultilineRequestCallAsync: true,
+		},
+	}
+
+	syncCode := pygen.RenderOperationMethod(doc, binding, false)
+	if strings.Contains(syncCode, "return self._requester.request(\n") {
+		t.Fatalf("sync request call should not be forced multiline by async-only option:\n%s", syncCode)
+	}
+
+	asyncCode := pygen.RenderOperationMethod(doc, binding, true)
+	if !strings.Contains(asyncCode, "return await self._requester.arequest(\n") {
+		t.Fatalf("async request call should be multiline when async-only option is enabled:\n%s", asyncCode)
 	}
 }
 

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -1443,9 +1443,6 @@ func renderOperationMethodWithContext(
 		if async && binding.Mapping.ForceMultilineRequestCallAsync {
 			forceMultilineRequestCall = true
 		}
-		if !async && binding.Mapping.ForceMultilineRequestCallSync {
-			forceMultilineRequestCall = true
-		}
 	}
 	if binding.Mapping != nil && binding.Mapping.ResponseUnwrapListFirst {
 		buf.WriteString(fmt.Sprintf("        res = %s\n", requestExpr))


### PR DESCRIPTION
## Summary
- remove `force_multiline_request_call_sync` from generator config schema
- remove sync-only request-call multiline branch in Python operation renderer
- delete the only config usage in `config/generator.yaml` (`bots.update`)
- add a renderer test to lock default behavior: async-only multiline override does not affect sync rendering

## Default behavior after this change
- sync and async request-call rendering now share the same option model:
  - common override: `force_multiline_request_call`
  - async-only override: `force_multiline_request_call_async`
- there is no sync-only override anymore

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 82.9%)
- `./scripts/build.sh`
- `./scripts/gengo.sh --output-sdk exist-repo/coze-go-generated`
- `./scripts/diffgo.sh` (0 diff)

## Downstream
- coze-py PR: https://github.com/coze-dev/coze-py/pull/384
