### PR TITLE
feat: remove sync/async-only mapping config

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4110,7 +4110,6 @@ api:
       order: 652
       sdk_methods:
         - datasets_documents.create
-      sync_only: true
       body_builder: raw
       ignore_header_params: true
       headers_expr: '{"Agw-Js-Conv": "str"}'
@@ -4132,32 +4131,6 @@ api:
         format_type: Optional[DocumentFormatType]
       arg_defaults_sync:
         format_type: "DocumentFormatType.DOCUMENT"
-      response_type: ListResponse[Document]
-      response_cast: ListResponse[Document]
-      data_field: document_infos
-    - path: /open_api/knowledge/document/create
-      method: post
-      order: 653
-      sdk_methods:
-        - datasets_documents.create
-      async_only: true
-      body_builder: raw
-      ignore_header_params: true
-      headers_expr: '{"Agw-Js-Conv": "str"}'
-      body_fields:
-        - dataset_id
-        - document_bases
-        - chunk_strategy
-      body_required_fields:
-        - dataset_id
-        - document_bases
-      body_field_values:
-        document_bases: "[i.model_dump() for i in document_bases]"
-        chunk_strategy: "chunk_strategy.model_dump() if chunk_strategy else None"
-      arg_types:
-        dataset_id: str
-        document_bases: List[DocumentBase]
-        chunk_strategy: Optional[DocumentChunkStrategy]
       response_type: ListResponse[Document]
       response_cast: ListResponse[Document]
       data_field: document_infos
@@ -4237,41 +4210,6 @@ api:
       order: 657
       sdk_methods:
         - knowledge_documents.create
-      sync_only: true
-      body_builder: raw
-      ignore_header_params: true
-      headers_expr: '{"Agw-Js-Conv": "str"}'
-      body_fields:
-        - dataset_id
-        - document_bases
-        - chunk_strategy
-      body_required_fields:
-        - dataset_id
-        - document_bases
-      body_field_values:
-        document_bases: "[i.model_dump() for i in document_bases]"
-        chunk_strategy: "chunk_strategy.model_dump() if chunk_strategy else None"
-      arg_types:
-        dataset_id: str
-        document_bases: List[DocumentBase]
-        chunk_strategy: Optional[DocumentChunkStrategy]
-      pre_docstring_code:
-        - |
-          warnings.warn(
-              "The 'coze.knowledge.documents.create' method is deprecated and will be removed in a future version. "
-              "Please use 'coze.datasets.documents.create' instead.",
-              DeprecationWarning,
-              stacklevel=2,
-          )
-      response_type: List[Document]
-      response_cast: "[Document]"
-      data_field: document_infos
-    - path: /open_api/knowledge/document/create
-      method: post
-      order: 658
-      sdk_methods:
-        - knowledge_documents.create
-      async_only: true
       body_builder: raw
       ignore_header_params: true
       headers_expr: '{"Agw-Js-Conv": "str"}'
@@ -4305,38 +4243,6 @@ api:
       order: 659
       sdk_methods:
         - knowledge_documents.update
-      sync_only: true
-      allow_missing_in_swagger: true
-      body_builder: raw
-      ignore_header_params: true
-      headers_expr: '{"Agw-Js-Conv": "str"}'
-      body_fields:
-        - document_id
-        - document_name
-        - update_rule
-      body_required_fields:
-        - document_id
-      arg_types:
-        document_id: str
-        document_name: str
-        update_rule: Optional[DocumentUpdateRule]
-      pre_docstring_code:
-        - |
-          warnings.warn(
-              "The 'coze.knowledge.documents.update' method is deprecated and will be removed in a future version. "
-              "Please use 'coze.datasets.documents.update' instead.",
-              DeprecationWarning,
-              stacklevel=2,
-          )
-      force_multiline_request_call: true
-      response_type: None
-      response_cast: None
-    - path: /open_api/knowledge/document/update
-      method: post
-      order: 660
-      sdk_methods:
-        - knowledge_documents.update
-      async_only: true
       allow_missing_in_swagger: true
       body_builder: raw
       ignore_header_params: true
@@ -4367,31 +4273,6 @@ api:
       order: 661
       sdk_methods:
         - knowledge_documents.delete
-      sync_only: true
-      body_builder: raw
-      ignore_header_params: true
-      headers_expr: '{"Agw-Js-Conv": "str"}'
-      body_fields:
-        - document_ids
-      arg_types:
-        document_ids: List[str]
-      pre_docstring_code:
-        - |
-          warnings.warn(
-              "The 'coze.knowledge.documents.delete' method is deprecated and will be removed in a future version. "
-              "Please use 'coze.datasets.documents.delete' instead.",
-              DeprecationWarning,
-              stacklevel=2,
-          )
-      force_multiline_request_call: true
-      response_type: None
-      response_cast: None
-    - path: /open_api/knowledge/document/delete
-      method: post
-      order: 662
-      sdk_methods:
-        - knowledge_documents.delete
-      async_only: true
       body_builder: raw
       ignore_header_params: true
       headers_expr: '{"Agw-Js-Conv": "str"}'

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -159,8 +159,6 @@ type OperationMapping struct {
 	DelegateCallArgs               []string          `yaml:"delegate_call_args"`
 	AsyncDelegateCallArgs          []string          `yaml:"async_delegate_call_args"`
 	DelegateAsyncYield             bool              `yaml:"delegate_async_yield"`
-	SyncOnly                       bool              `yaml:"sync_only"`
-	AsyncOnly                      bool              `yaml:"async_only"`
 	AllowMissingInSwagger          bool              `yaml:"allow_missing_in_swagger"`
 	HTTPMethodOverride             string            `yaml:"http_method_override"`
 	DisableRequestBody             bool              `yaml:"disable_request_body"`
@@ -503,9 +501,6 @@ func (c *Config) Validate() error {
 	for i, mapping := range c.API.OperationMappings {
 		if err := validateOperationRef(mapping.Path, mapping.Method, fmt.Sprintf("api.operation_mappings[%d]", i)); err != nil {
 			return err
-		}
-		if mapping.SyncOnly && mapping.AsyncOnly {
-			return fmt.Errorf("api.operation_mappings[%d] cannot set both sync_only and async_only", i)
 		}
 		if strings.TrimSpace(mapping.HTTPMethodOverride) != "" {
 			if err := validateOperationRef(mapping.Path, mapping.HTTPMethodOverride, fmt.Sprintf("api.operation_mappings[%d].http_method_override", i)); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -342,21 +342,6 @@ api:
 `,
 		},
 		{
-			name: "both sync and async only",
-			content: `
-language: python
-output_sdk: out
-api:
-  operation_mappings:
-    - path: /v3/chat
-      method: post
-      sdk_methods:
-        - chat.create
-      sync_only: true
-      async_only: true
-`,
-		},
-		{
 			name: "delegate args without target",
 			content: `
 language: python

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -17,17 +17,11 @@ type ClassMethodBlock struct {
 }
 
 func mappingGeneratesSync(mapping *config.OperationMapping) bool {
-	if mapping == nil {
-		return true
-	}
-	return !mapping.AsyncOnly
+	return true
 }
 
 func mappingGeneratesAsync(mapping *config.OperationMapping) bool {
-	if mapping == nil {
-		return true
-	}
-	return !mapping.SyncOnly
+	return true
 }
 
 func applyMethodDocstringOverrides(block string, classKey string, commentOverrides config.CommentOverrides) string {


### PR DESCRIPTION
## Summary
- remove the `sync_only` / `async_only` operation mapping config support from generator config and rendering logic
- define the default behavior as generating both sync and async client methods for every operation mapping
- remove duplicated knowledge document operation mappings that only existed to split sync/async generation

## Generator Changes
- deleted `sync_only` and `async_only` from `OperationMapping`
- removed validation branch for `sync_only && async_only`
- updated method generation guards to always generate both sides
- updated related config and generator unit tests

## Generated Python SDK Impact
- `AsyncDatasetsDocumentsClient.create` now accepts `format_type` and forwards it in request body

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 82.9%)
- `./scripts/build.sh`
- `./scripts/gengo.sh --output-sdk exist-repo/coze-go-generated --no-ci-check`
- `./scripts/diffgo.sh`
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-8ROqbK --ci-check`

## Downstream PR
- https://github.com/coze-dev/coze-py/pull/385
