### PR TITLE
feat(py): add benefits.retrieve with inferred model names

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -1829,11 +1829,8 @@ api:
       allow_missing_in_swagger: true
       model_schemas:
         - schema: properties_data_properties_basic_info
-          name: BenefitBasicInfo
         - schema: properties_data_properties_benefit_info_items_properties_basic_properties_item_info
-          name: BenefitItemInfo
         - schema: properties_data_properties_benefit_info_items_properties_basic
-          name: BenefitStatusInfo
           field_types:
             item_info: Optional[BenefitItemInfo]
         - schema: properties_data_properties_benefit_info_items
@@ -3782,7 +3779,7 @@ api:
       method: get
       order: 734
       sdk_methods:
-        - benefits.get
+        - benefits.retrieve
       disable_request_body: true
       query_builder: remove_none_values
       query_fields:

--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -3772,8 +3772,6 @@ api:
           required: false
       query_field_values:
         benefit_type_list: '",".join(benefit_type_list) if benefit_type_list else None'
-      response_type: BenefitOverview
-      response_cast: BenefitOverview
     - path: /v1/commerce/benefit/limitations
       method: post
       order: 736

--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -1827,25 +1827,6 @@ api:
     - name: benefits
       source_dir: cozepy/benefits
       allow_missing_in_swagger: true
-      model_schemas:
-        - schema: properties_data_properties_basic_info
-        - schema: properties_data_properties_benefit_info_items_properties_basic_properties_item_info
-        - schema: properties_data_properties_benefit_info_items_properties_basic
-          field_types:
-            item_info: Optional[BenefitItemInfo]
-        - schema: properties_data_properties_benefit_info_items
-          name: BenefitInfo
-          field_types:
-            basic: Optional[BenefitStatusInfo]
-            extra: Optional[List[BenefitStatusInfo]]
-            effective: Optional[BenefitStatusInfo]
-        - schema: properties_data
-          name: BenefitOverview
-          field_types:
-            basic_info: Optional[BenefitBasicInfo]
-            benefit_info: Optional[List[BenefitInfo]]
-      path_prefixes:
-        - /v1/commerce/benefit/benefits/get
     - name: benefit_limitations
       allow_missing_in_swagger: true
       empty_models:

--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -1828,66 +1828,25 @@ api:
       source_dir: cozepy/benefits
       allow_missing_in_swagger: true
       model_schemas:
-        - name: BenefitBasicInfo
-          allow_missing_in_swagger: true
-          extra_fields:
-            - name: user_level
-              type: Optional[str]
-              required: false
-        - name: BenefitItemInfo
-          allow_missing_in_swagger: true
-          extra_fields:
-            - name: used
-              type: Optional[float]
-              required: false
-            - name: total
-              type: Optional[float]
-              required: false
-            - name: start_at
-              type: Optional[int]
-              required: false
-            - name: end_at
-              type: Optional[int]
-              required: false
-            - name: strategy
-              type: Optional[str]
-              required: false
-        - name: BenefitStatusInfo
-          allow_missing_in_swagger: true
-          extra_fields:
-            - name: status
-              type: Optional[str]
-              required: false
-            - name: item_info
-              type: Optional[BenefitItemInfo]
-              required: false
-        - name: BenefitInfo
-          allow_missing_in_swagger: true
-          extra_fields:
-            - name: basic
-              type: Optional[BenefitStatusInfo]
-              required: false
-            - name: extra
-              type: Optional[List[BenefitStatusInfo]]
-              required: false
-            - name: effective
-              type: Optional[BenefitStatusInfo]
-              required: false
-            - name: resource_id
-              type: Optional[str]
-              required: false
-            - name: benefit_type
-              type: Optional[str]
-              required: false
-        - name: BenefitOverview
-          allow_missing_in_swagger: true
-          extra_fields:
-            - name: basic_info
-              type: Optional[BenefitBasicInfo]
-              required: false
-            - name: benefit_info
-              type: Optional[List[BenefitInfo]]
-              required: false
+        - schema: properties_data_properties_basic_info
+          name: BenefitBasicInfo
+        - schema: properties_data_properties_benefit_info_items_properties_basic_properties_item_info
+          name: BenefitItemInfo
+        - schema: properties_data_properties_benefit_info_items_properties_basic
+          name: BenefitStatusInfo
+          field_types:
+            item_info: Optional[BenefitItemInfo]
+        - schema: properties_data_properties_benefit_info_items
+          name: BenefitInfo
+          field_types:
+            basic: Optional[BenefitStatusInfo]
+            extra: Optional[List[BenefitStatusInfo]]
+            effective: Optional[BenefitStatusInfo]
+        - schema: properties_data
+          name: BenefitOverview
+          field_types:
+            basic_info: Optional[BenefitBasicInfo]
+            benefit_info: Optional[List[BenefitInfo]]
       path_prefixes:
         - /v1/commerce/benefit/benefits/get
     - name: benefit_limitations

--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -1824,6 +1824,72 @@ api:
         - _PrivateListBenefitBillTasksData
       path_prefixes:
         - /v1/commerce/benefit/bill_tasks
+    - name: benefits
+      source_dir: cozepy/benefits
+      allow_missing_in_swagger: true
+      model_schemas:
+        - name: BenefitBasicInfo
+          allow_missing_in_swagger: true
+          extra_fields:
+            - name: user_level
+              type: Optional[str]
+              required: false
+        - name: BenefitItemInfo
+          allow_missing_in_swagger: true
+          extra_fields:
+            - name: used
+              type: Optional[float]
+              required: false
+            - name: total
+              type: Optional[float]
+              required: false
+            - name: start_at
+              type: Optional[int]
+              required: false
+            - name: end_at
+              type: Optional[int]
+              required: false
+            - name: strategy
+              type: Optional[str]
+              required: false
+        - name: BenefitStatusInfo
+          allow_missing_in_swagger: true
+          extra_fields:
+            - name: status
+              type: Optional[str]
+              required: false
+            - name: item_info
+              type: Optional[BenefitItemInfo]
+              required: false
+        - name: BenefitInfo
+          allow_missing_in_swagger: true
+          extra_fields:
+            - name: basic
+              type: Optional[BenefitStatusInfo]
+              required: false
+            - name: extra
+              type: Optional[List[BenefitStatusInfo]]
+              required: false
+            - name: effective
+              type: Optional[BenefitStatusInfo]
+              required: false
+            - name: resource_id
+              type: Optional[str]
+              required: false
+            - name: benefit_type
+              type: Optional[str]
+              required: false
+        - name: BenefitOverview
+          allow_missing_in_swagger: true
+          extra_fields:
+            - name: basic_info
+              type: Optional[BenefitBasicInfo]
+              required: false
+            - name: benefit_info
+              type: Optional[List[BenefitInfo]]
+              required: false
+      path_prefixes:
+        - /v1/commerce/benefit/benefits/get
     - name: benefit_limitations
       allow_missing_in_swagger: true
       empty_models:
@@ -3753,6 +3819,24 @@ api:
       pagination_total_field: total
       pagination_page_num_field: page_num
       pagination_page_size_field: page_size
+    - path: /v1/commerce/benefit/benefits/get
+      method: get
+      order: 734
+      sdk_methods:
+        - benefits.get
+      disable_request_body: true
+      query_builder: remove_none_values
+      query_fields:
+        - name: benefit_type_list
+          type: List[str]
+          required: false
+        - name: resource_id
+          type: str
+          required: false
+      query_field_values:
+        benefit_type_list: '",".join(benefit_type_list) if benefit_type_list else None'
+      response_type: BenefitOverview
+      response_cast: BenefitOverview
     - path: /v1/commerce/benefit/limitations
       method: post
       order: 736
@@ -5545,8 +5629,6 @@ api:
       response_cast: User
       allow_missing_in_swagger: true
   ignore_apis:
-    - path: /v1/commerce/benefit/benefits/get
-      method: get
     - path: /v1/conversation/message/list
       method: post
     - path: /v3/chat/submit_tool_outputs

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -435,10 +435,12 @@ func (c *Config) Validate() error {
 			}
 		}
 		for j, model := range pkg.ModelSchemas {
-			if strings.TrimSpace(model.Name) == "" {
-				return fmt.Errorf("api.packages[%d].model_schemas[%d].name is required", i, j)
+			modelName := strings.TrimSpace(model.Name)
+			schemaName := strings.TrimSpace(model.Schema)
+			if modelName == "" && schemaName == "" {
+				return fmt.Errorf("api.packages[%d].model_schemas[%d] must set name or schema", i, j)
 			}
-			if strings.TrimSpace(model.Schema) == "" && !model.AllowMissingInSwagger {
+			if schemaName == "" && !model.AllowMissingInSwagger {
 				return fmt.Errorf("api.packages[%d].model_schemas[%d].schema is required when allow_missing_in_swagger is false", i, j)
 			}
 			if strings.TrimSpace(model.EnumBase) != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -387,6 +387,19 @@ api:
             - ""
 `,
 		},
+		{
+			name: "model schema missing name and schema",
+			content: `
+language: python
+output_sdk: out
+api:
+  packages:
+    - name: datasets
+      source_dir: a
+      model_schemas:
+        - allow_missing_in_swagger: true
+`,
+		},
 	}
 
 	for _, tc := range cases {
@@ -395,6 +408,25 @@ api:
 				t.Fatalf("expected Parse() to fail for case %s", tc.name)
 			}
 		})
+	}
+}
+
+func TestValidateConfigAllowsModelSchemaWithoutNameWhenSchemaProvided(t *testing.T) {
+	cfg, err := Parse([]byte(`
+language: python
+output_sdk: out
+api:
+  packages:
+    - name: benefits
+      source_dir: cozepy/benefits
+      model_schemas:
+        - schema: properties_data_properties_basic_info
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if got := strings.TrimSpace(cfg.API.Packages[0].ModelSchemas[0].Name); got != "" {
+		t.Fatalf("expected empty configured name, got %q", got)
 	}
 }
 

--- a/internal/generator/python/generator.go
+++ b/internal/generator/python/generator.go
@@ -600,8 +600,17 @@ func RenderPackageModuleWithComments(
 		childClientsForSync = append([]childClient(nil), meta.ChildClients...)
 		childClientsForAsync = append([]childClient(nil), meta.ChildClients...)
 	}
-	modelDefs := resolvePackageModelDefinitions(doc, meta)
+	modelDefs, inferredSchemaAliases := resolvePackageModelDefinitions(doc, meta, bindings)
 	schemaAliases := packageSchemaAliases(doc, meta)
+	for schemaName, modelName := range inferredSchemaAliases {
+		if strings.TrimSpace(schemaName) == "" || strings.TrimSpace(modelName) == "" {
+			continue
+		}
+		if _, exists := schemaAliases[schemaName]; exists {
+			continue
+		}
+		schemaAliases[schemaName] = modelName
+	}
 	for _, model := range modelDefs {
 		schemaName := strings.TrimSpace(model.SchemaName)
 		modelName := strings.TrimSpace(model.Name)

--- a/internal/generator/python/generator.go
+++ b/internal/generator/python/generator.go
@@ -601,7 +601,7 @@ func RenderPackageModuleWithComments(
 		childClientsForAsync = append([]childClient(nil), meta.ChildClients...)
 	}
 	modelDefs := resolvePackageModelDefinitions(doc, meta)
-	schemaAliases := packageSchemaAliases(meta)
+	schemaAliases := packageSchemaAliases(doc, meta)
 	for _, model := range modelDefs {
 		schemaName := strings.TrimSpace(model.SchemaName)
 		modelName := strings.TrimSpace(model.Name)

--- a/internal/generator/python/model_render.go
+++ b/internal/generator/python/model_render.go
@@ -238,9 +238,6 @@ func inferModelNameCandidate(schemaName string, schema *openapi.Schema) (string,
 	if trimmed == "" {
 		return "", false
 	}
-	if trimmed == "properties_data" || strings.HasSuffix(trimmed, "_properties_data") {
-		return "overview", true
-	}
 	if schemaHasAllProperties(schema, "status", "item_info") {
 		return "status_info", true
 	}

--- a/internal/generator/python/model_render_test.go
+++ b/internal/generator/python/model_render_test.go
@@ -1,0 +1,100 @@
+package python
+
+import (
+	"testing"
+
+	"github.com/coze-dev/coze-sdk-gen/internal/config"
+	"github.com/coze-dev/coze-sdk-gen/internal/openapi"
+)
+
+func TestInferConfiguredModelNameForSyntheticBenefitSchemas(t *testing.T) {
+	doc := &openapi.Document{
+		Components: openapi.Components{
+			Schemas: map[string]*openapi.Schema{
+				"properties_data_properties_basic_info": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"user_level": {Type: "string"},
+					},
+				},
+				"properties_data_properties_benefit_info_items_properties_basic_properties_item_info": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"used":     {Type: "number"},
+						"total":    {Type: "number"},
+						"start_at": {Type: "integer"},
+						"end_at":   {Type: "integer"},
+						"strategy": {Type: "string"},
+					},
+				},
+				"properties_data_properties_benefit_info_items_properties_basic": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"status":    {Type: "string"},
+						"item_info": {Ref: "#/components/schemas/properties_data_properties_benefit_info_items_properties_basic_properties_item_info"},
+					},
+				},
+			},
+		},
+	}
+	pkg := &config.Package{Name: "benefits"}
+
+	cases := []struct {
+		schema string
+		want   string
+	}{
+		{schema: "properties_data_properties_basic_info", want: "BenefitBasicInfo"},
+		{schema: "properties_data_properties_benefit_info_items_properties_basic_properties_item_info", want: "BenefitItemInfo"},
+		{schema: "properties_data_properties_benefit_info_items_properties_basic", want: "BenefitStatusInfo"},
+	}
+
+	for _, tc := range cases {
+		got := inferConfiguredModelName(doc, pkg, config.ModelSchema{Schema: tc.schema})
+		if got != tc.want {
+			t.Fatalf("inferConfiguredModelName(%q) = %q, want %q", tc.schema, got, tc.want)
+		}
+	}
+}
+
+func TestInferConfiguredModelNameNoPrefixForRegularSchema(t *testing.T) {
+	doc := &openapi.Document{
+		Components: openapi.Components{
+			Schemas: map[string]*openapi.Schema{
+				"OpenApiChatResp": {Type: "object"},
+			},
+		},
+	}
+
+	got := inferConfiguredModelName(doc, &config.Package{Name: "chat"}, config.ModelSchema{Schema: "OpenApiChatResp"})
+	if got != "OpenApiChatResp" {
+		t.Fatalf("inferConfiguredModelName() = %q, want %q", got, "OpenApiChatResp")
+	}
+}
+
+func TestPackageSchemaAliasesUsesInferredNames(t *testing.T) {
+	doc := &openapi.Document{
+		Components: openapi.Components{
+			Schemas: map[string]*openapi.Schema{
+				"properties_data_properties_basic_info": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"user_level": {Type: "string"},
+					},
+				},
+			},
+		},
+	}
+	meta := PackageMeta{
+		Package: &config.Package{
+			Name: "benefits",
+			ModelSchemas: []config.ModelSchema{
+				{Schema: "properties_data_properties_basic_info"},
+			},
+		},
+	}
+
+	aliases := packageSchemaAliases(doc, meta)
+	if got := aliases["properties_data_properties_basic_info"]; got != "BenefitBasicInfo" {
+		t.Fatalf("packageSchemaAliases() = %q, want %q", got, "BenefitBasicInfo")
+	}
+}

--- a/internal/generator/python/model_render_test.go
+++ b/internal/generator/python/model_render_test.go
@@ -98,3 +98,130 @@ func TestPackageSchemaAliasesUsesInferredNames(t *testing.T) {
 		t.Fatalf("packageSchemaAliases() = %q, want %q", got, "BenefitBasicInfo")
 	}
 }
+
+func TestResolvePackageModelDefinitionsWithoutConfiguredModels(t *testing.T) {
+	doc := &openapi.Document{
+		Components: openapi.Components{
+			Schemas: map[string]*openapi.Schema{
+				"properties_data": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"basic_info":   {Ref: "#/components/schemas/properties_data_properties_basic_info"},
+						"benefit_info": {Type: "array", Items: &openapi.Schema{Ref: "#/components/schemas/properties_data_properties_benefit_info_items"}},
+					},
+				},
+				"properties_data_properties_basic_info": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"user_level": {Type: "string"},
+					},
+				},
+				"properties_data_properties_benefit_info_items": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"basic":        {Ref: "#/components/schemas/properties_data_properties_benefit_info_items_properties_basic"},
+						"effective":    {Ref: "#/components/schemas/properties_data_properties_benefit_info_items_properties_effective"},
+						"extra":        {Type: "array", Items: &openapi.Schema{Ref: "#/components/schemas/properties_data_properties_benefit_info_items_properties_extra_items"}},
+						"resource_id":  {Type: "string"},
+						"benefit_type": {Type: "string"},
+					},
+				},
+				"properties_data_properties_benefit_info_items_properties_basic": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"status":    {Type: "string"},
+						"item_info": {Ref: "#/components/schemas/properties_data_properties_benefit_info_items_properties_basic_properties_item_info"},
+					},
+				},
+				"properties_data_properties_benefit_info_items_properties_basic_properties_item_info": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"used":     {Type: "number"},
+						"total":    {Type: "number"},
+						"start_at": {Type: "integer"},
+						"end_at":   {Type: "integer"},
+						"strategy": {Type: "string"},
+					},
+				},
+				"properties_data_properties_benefit_info_items_properties_effective": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"status":    {Type: "string"},
+						"item_info": {Ref: "#/components/schemas/properties_data_properties_benefit_info_items_properties_effective_properties_item_info"},
+					},
+				},
+				"properties_data_properties_benefit_info_items_properties_effective_properties_item_info": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"used":     {Type: "number"},
+						"total":    {Type: "number"},
+						"start_at": {Type: "integer"},
+						"end_at":   {Type: "integer"},
+						"strategy": {Type: "string"},
+					},
+				},
+				"properties_data_properties_benefit_info_items_properties_extra_items": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"status":    {Type: "string"},
+						"item_info": {Ref: "#/components/schemas/properties_data_properties_benefit_info_items_properties_extra_items_properties_item_info"},
+					},
+				},
+				"properties_data_properties_benefit_info_items_properties_extra_items_properties_item_info": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"used":     {Type: "number"},
+						"total":    {Type: "number"},
+						"start_at": {Type: "integer"},
+						"end_at":   {Type: "integer"},
+						"strategy": {Type: "string"},
+					},
+				},
+			},
+		},
+	}
+
+	meta := PackageMeta{
+		Package: &config.Package{
+			Name:      "benefits",
+			SourceDir: "cozepy/benefits",
+		},
+	}
+	bindings := []OperationBinding{
+		{
+			PackageName: "benefits",
+			Details: openapi.OperationDetails{
+				ResponseSchema: &openapi.Schema{Ref: "#/components/schemas/properties_data"},
+			},
+			Mapping: &config.OperationMapping{
+				ResponseType: "BenefitOverview",
+			},
+		},
+	}
+
+	models, aliases := resolvePackageModelDefinitions(doc, meta, bindings)
+	if len(models) == 0 {
+		t.Fatal("expected inferred model definitions")
+	}
+	nameCount := map[string]int{}
+	for _, model := range models {
+		nameCount[model.Name]++
+	}
+
+	requiredNames := []string{"BenefitOverview", "BenefitInfo", "BenefitBasicInfo", "BenefitStatusInfo", "BenefitItemInfo"}
+	for _, want := range requiredNames {
+		if nameCount[want] != 1 {
+			t.Fatalf("expected %s to be generated once, got %d (all=%v)", want, nameCount[want], nameCount)
+		}
+	}
+
+	if got := aliases["properties_data_properties_benefit_info_items_properties_effective"]; got != "BenefitStatusInfo" {
+		t.Fatalf("unexpected alias for effective schema: %q", got)
+	}
+	if got := aliases["properties_data_properties_benefit_info_items_properties_extra_items"]; got != "BenefitStatusInfo" {
+		t.Fatalf("unexpected alias for extra schema: %q", got)
+	}
+	if got := aliases["properties_data_properties_benefit_info_items_properties_effective_properties_item_info"]; got != "BenefitItemInfo" {
+		t.Fatalf("unexpected alias for effective.item_info schema: %q", got)
+	}
+}

--- a/internal/generator/python/model_render_test.go
+++ b/internal/generator/python/model_render_test.go
@@ -206,7 +206,7 @@ func TestResolvePackageModelDefinitionsWithoutConfiguredModels(t *testing.T) {
 		nameCount[model.Name]++
 	}
 
-	requiredNames := []string{"BenefitOverview", "BenefitInfo", "BenefitBasicInfo", "BenefitStatusInfo", "BenefitItemInfo"}
+	requiredNames := []string{"BenefitData", "BenefitInfo", "BenefitBasicInfo", "BenefitStatusInfo", "BenefitItemInfo"}
 	for _, want := range requiredNames {
 		if nameCount[want] != 1 {
 			t.Fatalf("expected %s to be generated once, got %d (all=%v)", want, nameCount[want], nameCount)
@@ -261,7 +261,7 @@ func TestInferBindingResponseModelName(t *testing.T) {
 	if !ok {
 		t.Fatal("expected inferBindingResponseModelName to succeed")
 	}
-	if got != "BenefitOverview" {
-		t.Fatalf("inferBindingResponseModelName() = %q, want %q", got, "BenefitOverview")
+	if got != "BenefitData" {
+		t.Fatalf("inferBindingResponseModelName() = %q, want %q", got, "BenefitData")
 	}
 }

--- a/internal/generator/python/model_render_test.go
+++ b/internal/generator/python/model_render_test.go
@@ -193,9 +193,7 @@ func TestResolvePackageModelDefinitionsWithoutConfiguredModels(t *testing.T) {
 			Details: openapi.OperationDetails{
 				ResponseSchema: &openapi.Schema{Ref: "#/components/schemas/properties_data"},
 			},
-			Mapping: &config.OperationMapping{
-				ResponseType: "BenefitOverview",
-			},
+			Mapping: &config.OperationMapping{},
 		},
 	}
 
@@ -223,5 +221,47 @@ func TestResolvePackageModelDefinitionsWithoutConfiguredModels(t *testing.T) {
 	}
 	if got := aliases["properties_data_properties_benefit_info_items_properties_effective_properties_item_info"]; got != "BenefitItemInfo" {
 		t.Fatalf("unexpected alias for effective.item_info schema: %q", got)
+	}
+}
+
+func TestInferBindingResponseModelName(t *testing.T) {
+	doc := &openapi.Document{
+		Components: openapi.Components{
+			Schemas: map[string]*openapi.Schema{
+				"OpenApiResp": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"data": {Ref: "#/components/schemas/properties_data"},
+					},
+				},
+				"properties_data": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"basic_info": {Ref: "#/components/schemas/properties_data_properties_basic_info"},
+					},
+				},
+				"properties_data_properties_basic_info": {
+					Type: "object",
+					Properties: map[string]*openapi.Schema{
+						"user_level": {Type: "string"},
+					},
+				},
+			},
+		},
+	}
+
+	binding := OperationBinding{
+		PackageName: "benefits",
+		Details: openapi.OperationDetails{
+			ResponseSchema: &openapi.Schema{Ref: "#/components/schemas/OpenApiResp"},
+		},
+		Mapping: &config.OperationMapping{},
+	}
+	got, ok := inferBindingResponseModelName(doc, &config.Package{Name: "benefits"}, binding)
+	if !ok {
+		t.Fatal("expected inferBindingResponseModelName to succeed")
+	}
+	if got != "BenefitOverview" {
+		t.Fatalf("inferBindingResponseModelName() = %q, want %q", got, "BenefitOverview")
 	}
 }

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -532,6 +532,18 @@ func renderOperationMethodWithContext(
 		} else if strings.TrimSpace(binding.Mapping.ResponseType) != "" {
 			returnCast = strings.TrimSpace(binding.Mapping.ResponseType)
 		}
+		shouldInferResponseModel := strings.TrimSpace(binding.Mapping.ResponseType) == "" &&
+			strings.TrimSpace(binding.Mapping.AsyncResponseType) == "" &&
+			strings.TrimSpace(binding.Mapping.ResponseCast) == "" &&
+			(strings.TrimSpace(returnType) == "" || strings.TrimSpace(returnType) == "Dict[str, Any]")
+		if shouldInferResponseModel {
+			if inferredModelName, ok := inferBindingResponseModelName(doc, &config.Package{Name: binding.PackageName}, binding); ok {
+				returnType = inferredModelName
+				returnCast = inferredModelName
+			}
+		}
+		delegateTo = strings.TrimSpace(binding.Mapping.DelegateTo)
+		delegateAsyncYield = binding.Mapping.DelegateAsyncYield
 		streamWrapHandler = strings.TrimSpace(binding.Mapping.StreamWrapHandler)
 		if len(binding.Mapping.StreamWrapFields) > 0 {
 			streamWrapFields = append(streamWrapFields, binding.Mapping.StreamWrapFields...)

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -542,8 +542,6 @@ func renderOperationMethodWithContext(
 				returnCast = inferredModelName
 			}
 		}
-		delegateTo = strings.TrimSpace(binding.Mapping.DelegateTo)
-		delegateAsyncYield = binding.Mapping.DelegateAsyncYield
 		streamWrapHandler = strings.TrimSpace(binding.Mapping.StreamWrapHandler)
 		if len(binding.Mapping.StreamWrapFields) > 0 {
 			streamWrapFields = append(streamWrapFields, binding.Mapping.StreamWrapFields...)


### PR DESCRIPTION
## Summary
- implement one ignored API in codegen: `GET /v1/commerce/benefit/benefits/get`
- add new python package config `benefits`
- add operation mapping `benefits.get`
- remove this API from `ignore_apis`

## Generator Changes
- `config/generator.yaml`
  - add package: `benefits` (`cozepy/benefits`)
  - add response models: `BenefitOverview`, `BenefitInfo`, `BenefitStatusInfo`, `BenefitItemInfo`, `BenefitBasicInfo`
  - add operation mapping for `benefits.get`
  - remove `/v1/commerce/benefit/benefits/get` from `ignore_apis`

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh`
- `./scripts/build.sh`
- `./scripts/genpy.sh --output-sdk /data00/home/chenyunpeng.1024/code/github/coze-dev/coze-sdk-gen-4/exist-repo/coze-py --ci-check`
