### PR TITLE
fix: preserve richtext docstring paragraph formatting

### DIFF
--- a/internal/generator/python/richtext_test.go
+++ b/internal/generator/python/richtext_test.go
@@ -1,14 +1,41 @@
 package python
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestExtractSwaggerRichTextDeterministicOrder(t *testing.T) {
 	raw := `{"b":{"ops":[{"insert":"second"}]},"a":{"ops":[{"insert":"first"}]}}`
 
 	for i := 0; i < 128; i++ {
 		got := extractSwaggerRichText(raw)
-		if got != "first second" {
-			t.Fatalf("extractSwaggerRichText() = %q, want %q", got, "first second")
+		flat := strings.ReplaceAll(strings.ReplaceAll(got, "\n", ""), " ", "")
+		if flat != "firstsecond" {
+			t.Fatalf("extractSwaggerRichText() = %q, normalized=%q, want %q", got, flat, "firstsecond")
 		}
+	}
+}
+
+func TestExtractSwaggerRichTextPreservesLineBreaks(t *testing.T) {
+	raw := `{"0":{"ops":[{"insert":"删除扣子应用的协作者。\n"},{"attributes":{"lmkr":"1"},"insert":"*"},{"insert":"删除协作者时，扣子会将该协作者创建的工作流、插件等资源转移给应用的所有者。\n"},{"attributes":{"anchor":"3dc926e4","heading":"h2","lmkr":"1"},"insert":"*"},{"insert":"接口限制\n"},{"attributes":{"list":"bullet1","lmkr":"1"},"insert":"*"},{"insert":"每次请求只能删除一位协作者。如需删除多位，请依次发送请求。\n"}]}}`
+	got := extractSwaggerRichText(raw)
+	want := strings.Join([]string{
+		"删除扣子应用的协作者。",
+		"删除协作者时，扣子会将该协作者创建的工作流、插件等资源转移给应用的所有者。",
+		"接口限制",
+		"每次请求只能删除一位协作者。如需删除多位，请依次发送请求。",
+	}, "\n")
+	if got != want {
+		t.Fatalf("extractSwaggerRichText() = %q, want %q", got, want)
+	}
+}
+
+func TestExtractSwaggerRichTextKeepsInlineStyledText(t *testing.T) {
+	raw := `{"0":{"ops":[{"insert":"使用"},{"attributes":{"bold":"true"},"insert":"OAuth"},{"insert":" 应用和服务访问令牌时，只需要有对应权限点即可。"}]}}`
+	got := extractSwaggerRichText(raw)
+	want := "使用OAuth 应用和服务访问令牌时，只需要有对应权限点即可。"
+	if got != want {
+		t.Fatalf("extractSwaggerRichText() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- preserve line breaks when extracting swagger rich-text descriptions instead of flattening everything into one line
- keep inline fragment spacing safe for latin words while avoiding unnecessary CJK spacing
- normalize collapsed richtext override docstrings into readable paragraph lines (for headings like 接口限制/接口描述)
- add rendering tests to lock behavior for rich-text extraction and override normalization

## Generator Changes
- update rich-text parsing in `internal/generator/python/model_render.go`
- add richtext override normalization helpers in `internal/generator/python/operation_render.go`
- extend tests in `internal/generator/python/richtext_test.go` and `internal/generator/generator_rendering_test.go`

## Validation
- ./scripts/fmt.sh
- ./scripts/lint.sh
- ./scripts/test.sh (Total coverage: 83.0%)
- ./scripts/build.sh

## Downstream
- coze-py PR: https://github.com/coze-dev/coze-py/pull/389
