### PR TITLE
refactor: remove pagination_params_variable config

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -5425,7 +5425,6 @@ api:
       pagination_page_token_field: page_token
       pagination_page_size_field: page_size
       pagination_init_page_token_expr: page_token or ""
-      pagination_params_variable: true
     - path: /v1/workflows/{workflow_id}/collaborators/{user_id}
       method: delete
       order: 951

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -225,7 +225,6 @@ type OperationMapping struct {
 	PaginationHTTPMethod           string            `yaml:"pagination_http_method"`
 	PaginationRequestArg           string            `yaml:"pagination_request_arg"`
 	PaginationInitPageTokenExpr    string            `yaml:"pagination_init_page_token_expr"`
-	PaginationParamsVariable       bool              `yaml:"pagination_params_variable"`
 }
 
 type OperationField struct {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1151,6 +1151,9 @@ func TestRenderOperationMethodPaginationQueryBuilderAndTokenOverrides(t *testing
 	if !strings.Contains(syncCode, "params=dump_exclude_none(") {
 		t.Fatalf("expected sync query builder override:\n%s", syncCode)
 	}
+	if strings.Contains(syncCode, "params = dump_exclude_none(") {
+		t.Fatalf("expected sync token pagination params to be inlined:\n%s", syncCode)
+	}
 	if !strings.Contains(syncCode, "page_token=page_token or \"\"") {
 		t.Fatalf("expected custom pagination token init expr in sync code:\n%s", syncCode)
 	}
@@ -1166,6 +1169,9 @@ func TestRenderOperationMethodPaginationQueryBuilderAndTokenOverrides(t *testing
 	}
 	if !strings.Contains(asyncCode, "params=dump_exclude_none(") {
 		t.Fatalf("expected async query builder to follow query_builder:\n%s", asyncCode)
+	}
+	if strings.Contains(asyncCode, "params = dump_exclude_none(") {
+		t.Fatalf("expected async token pagination params to be inlined:\n%s", asyncCode)
 	}
 	if !strings.Contains(asyncCode, "page_token=page_token or \"\"") {
 		t.Fatalf("expected custom pagination token init expr in async code:\n%s", asyncCode)

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -815,7 +815,6 @@ func renderOperationMethodWithContext(
 
 	if isTokenPagination(paginationMode) && binding.Mapping != nil {
 		dataClass := strings.TrimSpace(binding.Mapping.PaginationDataClass)
-		paginationParamsVariable := binding.Mapping.PaginationParamsVariable
 		pageTokenField := strings.TrimSpace(binding.Mapping.PaginationPageTokenField)
 		if pageTokenField == "" {
 			pageTokenField = "page_token"
@@ -840,75 +839,40 @@ func renderOperationMethodWithContext(
 		EnsureTrailingNewlines(&buf, 2)
 		if async {
 			buf.WriteString("        async def request_maker(i_page_token: str, i_page_size: int) -> HTTPRequest:\n")
-			if paginationParamsVariable {
-				if queryBuilder == "raw" {
-					buf.WriteString("            params = {\n")
-				} else {
-					buf.WriteString(fmt.Sprintf("            params = %s(\n", queryBuilder))
-					buf.WriteString("                {\n")
-				}
-				itemIndent := "                    "
-				if queryBuilder != "raw" {
-					itemIndent = "                    "
-				}
-				for _, field := range queryFields {
-					valueExpr := field.ValueExpr
-					if strings.TrimSpace(valueExpr) == "" {
-						valueExpr = field.ArgName
-					}
-					if field.RawName == pageTokenField {
-						valueExpr = "i_page_token"
-					}
-					if field.RawName == pageSizeField {
-						valueExpr = "i_page_size"
-					}
-					buf.WriteString(fmt.Sprintf("%s%q: %s,\n", itemIndent, field.RawName, valueExpr))
-				}
-				if queryBuilder == "raw" {
-					buf.WriteString("            }\n")
-				} else {
-					buf.WriteString("                }\n")
-					buf.WriteString("            )\n")
-				}
-			}
 			buf.WriteString("            return await self._requester.amake_request(\n")
 			buf.WriteString(fmt.Sprintf("                %q,\n", paginationRequestMethod))
 			buf.WriteString("                url,\n")
 			if headersBeforePaginationParams && includePaginationHeaders {
 				buf.WriteString("                headers=headers,\n")
 			}
-			if paginationParamsVariable {
-				buf.WriteString(fmt.Sprintf("                %s=params,\n", paginationRequestArg))
+			if queryBuilder == "raw" {
+				buf.WriteString(fmt.Sprintf("                %s={\n", paginationRequestArg))
 			} else {
-				if queryBuilder == "raw" {
-					buf.WriteString(fmt.Sprintf("                %s={\n", paginationRequestArg))
-				} else {
-					buf.WriteString(fmt.Sprintf("                %s=%s(\n", paginationRequestArg, queryBuilder))
-					buf.WriteString("                    {\n")
+				buf.WriteString(fmt.Sprintf("                %s=%s(\n", paginationRequestArg, queryBuilder))
+				buf.WriteString("                    {\n")
+			}
+			itemIndent := "                        "
+			if queryBuilder == "raw" {
+				itemIndent = "                    "
+			}
+			for _, field := range queryFields {
+				valueExpr := field.ValueExpr
+				if strings.TrimSpace(valueExpr) == "" {
+					valueExpr = field.ArgName
 				}
-				itemIndent := "                        "
-				if queryBuilder == "raw" {
-					itemIndent = "                    "
+				if field.RawName == pageTokenField {
+					valueExpr = "i_page_token"
 				}
-				for _, field := range queryFields {
-					valueExpr := field.ValueExpr
-					if strings.TrimSpace(valueExpr) == "" {
-						valueExpr = field.ArgName
-					}
-					if field.RawName == pageTokenField {
-						valueExpr = "i_page_token"
-					}
-					if field.RawName == pageSizeField {
-						valueExpr = "i_page_size"
-					}
-					buf.WriteString(fmt.Sprintf("%s%q: %s,\n", itemIndent, field.RawName, valueExpr))
+				if field.RawName == pageSizeField {
+					valueExpr = "i_page_size"
 				}
-				if queryBuilder == "raw" {
-					buf.WriteString("                },\n")
-				} else {
-					buf.WriteString("                    }\n")
-					buf.WriteString("                ),\n")
-				}
+				buf.WriteString(fmt.Sprintf("%s%q: %s,\n", itemIndent, field.RawName, valueExpr))
+			}
+			if queryBuilder == "raw" {
+				buf.WriteString("                },\n")
+			} else {
+				buf.WriteString("                    }\n")
+				buf.WriteString("                ),\n")
 			}
 			if includePaginationHeaders {
 				if paginationCastBeforeHeaders && !headersBeforePaginationParams {
@@ -936,75 +900,40 @@ func renderOperationMethodWithContext(
 			buf.WriteString("        )\n")
 		} else {
 			buf.WriteString("        def request_maker(i_page_token: str, i_page_size: int) -> HTTPRequest:\n")
-			if paginationParamsVariable {
-				if queryBuilder == "raw" {
-					buf.WriteString("            params = {\n")
-				} else {
-					buf.WriteString(fmt.Sprintf("            params = %s(\n", queryBuilder))
-					buf.WriteString("                {\n")
-				}
-				itemIndent := "                    "
-				if queryBuilder != "raw" {
-					itemIndent = "                    "
-				}
-				for _, field := range queryFields {
-					valueExpr := field.ValueExpr
-					if strings.TrimSpace(valueExpr) == "" {
-						valueExpr = field.ArgName
-					}
-					if field.RawName == pageTokenField {
-						valueExpr = "i_page_token"
-					}
-					if field.RawName == pageSizeField {
-						valueExpr = "i_page_size"
-					}
-					buf.WriteString(fmt.Sprintf("%s%q: %s,\n", itemIndent, field.RawName, valueExpr))
-				}
-				if queryBuilder == "raw" {
-					buf.WriteString("            }\n")
-				} else {
-					buf.WriteString("                }\n")
-					buf.WriteString("            )\n")
-				}
-			}
 			buf.WriteString("            return self._requester.make_request(\n")
 			buf.WriteString(fmt.Sprintf("                %q,\n", paginationRequestMethod))
 			buf.WriteString("                url,\n")
 			if headersBeforePaginationParams && includePaginationHeaders {
 				buf.WriteString("                headers=headers,\n")
 			}
-			if paginationParamsVariable {
-				buf.WriteString(fmt.Sprintf("                %s=params,\n", paginationRequestArg))
+			if queryBuilder == "raw" {
+				buf.WriteString(fmt.Sprintf("                %s={\n", paginationRequestArg))
 			} else {
-				if queryBuilder == "raw" {
-					buf.WriteString(fmt.Sprintf("                %s={\n", paginationRequestArg))
-				} else {
-					buf.WriteString(fmt.Sprintf("                %s=%s(\n", paginationRequestArg, queryBuilder))
-					buf.WriteString("                    {\n")
+				buf.WriteString(fmt.Sprintf("                %s=%s(\n", paginationRequestArg, queryBuilder))
+				buf.WriteString("                    {\n")
+			}
+			itemIndent := "                        "
+			if queryBuilder == "raw" {
+				itemIndent = "                    "
+			}
+			for _, field := range queryFields {
+				valueExpr := field.ValueExpr
+				if strings.TrimSpace(valueExpr) == "" {
+					valueExpr = field.ArgName
 				}
-				itemIndent := "                        "
-				if queryBuilder == "raw" {
-					itemIndent = "                    "
+				if field.RawName == pageTokenField {
+					valueExpr = "i_page_token"
 				}
-				for _, field := range queryFields {
-					valueExpr := field.ValueExpr
-					if strings.TrimSpace(valueExpr) == "" {
-						valueExpr = field.ArgName
-					}
-					if field.RawName == pageTokenField {
-						valueExpr = "i_page_token"
-					}
-					if field.RawName == pageSizeField {
-						valueExpr = "i_page_size"
-					}
-					buf.WriteString(fmt.Sprintf("%s%q: %s,\n", itemIndent, field.RawName, valueExpr))
+				if field.RawName == pageSizeField {
+					valueExpr = "i_page_size"
 				}
-				if queryBuilder == "raw" {
-					buf.WriteString("                },\n")
-				} else {
-					buf.WriteString("                    }\n")
-					buf.WriteString("                ),\n")
-				}
+				buf.WriteString(fmt.Sprintf("%s%q: %s,\n", itemIndent, field.RawName, valueExpr))
+			}
+			if queryBuilder == "raw" {
+				buf.WriteString("                },\n")
+			} else {
+				buf.WriteString("                    }\n")
+				buf.WriteString("                ),\n")
 			}
 			if includePaginationHeaders {
 				if paginationCastBeforeHeaders && !headersBeforePaginationParams {


### PR DESCRIPTION
## Summary
- remove `pagination_params_variable` from `config/generator.yaml` and `OperationMapping`
- simplify Python token-pagination renderer to always inline query params in `request_maker`
- add generator regression assertions to lock the new default behavior (no intermediate `params` variable)

## Behavior Change
- default behavior for token pagination now always generates inline `params=...` in requester calls
- `/v1/workflows/{workflow_id}/versions` no longer needs a per-API compatibility knob

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 82.9%)
- `./scripts/build.sh`
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-6tfEzG --ci-check`

## Downstream PR
- coze-py: https://github.com/coze-dev/coze-py/pull/390
