### PR TITLE
refactor(codegen): remove compact_single_item_maps compatibility config

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -3954,7 +3954,6 @@ api:
       order: 59
       sdk_methods:
         - conversations.update
-      compact_single_item_maps: true
       body_builder: raw
       body_fields:
         - name
@@ -4434,7 +4433,6 @@ api:
       order: 70
       sdk_methods:
         - bots._retrieve_v1
-      compact_single_item_maps: true
       query_builder: raw
       response_type: Bot
       response_cast: Bot
@@ -4443,7 +4441,6 @@ api:
       order: 71
       sdk_methods:
         - bots._retrieve_v2
-      compact_single_item_maps: true
       query_builder: remove_none_values
       response_type: Bot
       response_cast: Bot
@@ -5179,7 +5176,6 @@ api:
         - users
       body_required_fields:
         - users
-      compact_single_item_maps_async: true
       arg_types:
         users: List[EnterpriseMember]
       stream_keyword: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,9 +207,6 @@ type OperationMapping struct {
 	BodyCallExpr                   string            `yaml:"body_call_expr"`
 	BodyFieldValues                map[string]string `yaml:"body_field_values"`
 	HeadersExpr                    string            `yaml:"headers_expr"`
-	CompactSingleItemMaps          bool              `yaml:"compact_single_item_maps"`
-	CompactSingleItemMapsSync      bool              `yaml:"compact_single_item_maps_sync"`
-	CompactSingleItemMapsAsync     bool              `yaml:"compact_single_item_maps_async"`
 	BlankLineAfterHeaders          bool              `yaml:"blank_line_after_headers"`
 	NoBlankLineAfterHeaders        bool              `yaml:"no_blank_line_after_headers"`
 	BlankLineAfterDocstring        bool              `yaml:"blank_line_after_docstring"`


### PR DESCRIPTION
## Summary
- remove the `compact_single_item_maps*` compatibility configuration from `config/generator.yaml`
- remove related config fields from `internal/config/config.go`
- remove branch logic in Python operation rendering that compacted single-item query/body dict literals
- define the default behavior as always rendering single-item request maps in multiline form for consistent output style
- add generator test coverage to lock the new default behavior

## Generator Changes
- deleted `compact_single_item_maps`, `compact_single_item_maps_sync`, `compact_single_item_maps_async` support from operation mapping config
- updated `RenderOperationMethod` to use one map-rendering path (multiline) for query/body assignments
- added `TestRenderOperationMethodSingleItemMapsUseMultilineFormat`

## SDK Output Impact
- generated Python SDK no longer emits one-line single-item request maps for the previously configured methods
- no API additions/removals and no signature changes

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.1%)
- `./scripts/build.sh`
- `./scripts/gengo.sh --output-sdk /tmp/coze-sdk-work-n5IAl4/coze-go --ci-check`
- `./scripts/genpy.sh --output-sdk /tmp/coze-sdk-work-n5IAl4/coze-py --ci-check` (283 passed)

## Downstream PR
- https://github.com/coze-dev/coze-py/pull/392
