### PR TITLE
refactor(codegen): remove stream_keyword compatibility mapping

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4601,7 +4601,6 @@ api:
       no_blank_line_after_headers: true
       force_multiline_signature: true
       http_method_override: GET
-      stream_keyword: true
       response_type: SimpleFolder
       response_cast: SimpleFolder
     - path: /v1/folders
@@ -4718,7 +4717,6 @@ api:
         uid: str
         workflow_id: str
         config: RoomConfig
-      stream_keyword: true
       response_type: CreateRoomResp
       response_cast: CreateRoomResp
     - path: /v1/audio/speech
@@ -4749,7 +4747,6 @@ api:
         response_format: AudioFormat.MP3
         speed: "1"
         sample_rate: "24000"
-      stream_keyword: true
       response_type: FileHTTPResponse
       response_cast: FileHTTPResponse
     - path: /v1/audio/transcriptions
@@ -4765,7 +4762,6 @@ api:
         file: _try_fix_file(file)
       arg_types:
         file: FileTypes
-      stream_keyword: true
       response_type: CreateTranscriptionsResp
       response_cast: CreateTranscriptionsResp
     - path: /v1/audio/live/{live_id}
@@ -4775,7 +4771,6 @@ api:
         - audio_live.retrieve
       allow_missing_in_swagger: true
       disable_request_body: true
-      stream_keyword: true
       force_multiline_signature: true
       response_type: LiveInfo
       response_cast: LiveInfo
@@ -5197,7 +5192,6 @@ api:
         - users
       arg_types:
         users: List[EnterpriseMember]
-      stream_keyword: true
       response_type: CreateEnterpriseMemberResp
       response_cast: CreateEnterpriseMemberResp
     - path: /v1/enterprises/{enterprise_id}/organizations
@@ -5227,7 +5221,6 @@ api:
         - role
       arg_types:
         role: EnterpriseMemberRole
-      stream_keyword: true
       response_type: UpdateEnterpriseMemberResp
       response_cast: UpdateEnterpriseMemberResp
     - path: /v1/enterprises/{enterprise_id}/members/{user_id}
@@ -5243,7 +5236,6 @@ api:
         - receiver_user_id
       arg_types:
         receiver_user_id: str
-      stream_keyword: true
       response_type: DeleteEnterpriseMemberResp
       response_cast: DeleteEnterpriseMemberResp
     - path: /v1/workflow/run
@@ -5486,7 +5478,6 @@ api:
         - user_ids
       arg_types:
         user_ids: List[str]
-      stream_keyword: true
       response_type: DeleteWorkspaceMemberResp
       response_cast: DeleteWorkspaceMemberResp
     - path: /v1/workspaces/{workspace_id}/members
@@ -5511,7 +5502,6 @@ api:
           ]
       arg_types:
         users: List[WorkspaceMember]
-      stream_keyword: true
       response_type: CreateWorkspaceMemberResp
       response_cast: CreateWorkspaceMemberResp
     - path: /v1/workspaces/{workspace_id}/members

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,7 +174,6 @@ type OperationMapping struct {
 	ResponseType                   string            `yaml:"response_type"`
 	AsyncResponseType              string            `yaml:"async_response_type"`
 	ResponseCast                   string            `yaml:"response_cast"`
-	StreamKeyword                  bool              `yaml:"stream_keyword"`
 	QueryFields                    []OperationField  `yaml:"query_fields"`
 	QueryFieldValues               map[string]string `yaml:"query_field_values"`
 	ArgDefaults                    map[string]string `yaml:"arg_defaults"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -474,7 +474,7 @@ func TestRenderOperationMethodAdvancedOptions(t *testing.T) {
 	}
 }
 
-func TestRenderOperationMethodStreamWrapAndKeywords(t *testing.T) {
+func TestRenderOperationMethodStreamWrap(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{
 		Path:   "/v1/demo/stream",
@@ -492,21 +492,20 @@ func TestRenderOperationMethodStreamWrapAndKeywords(t *testing.T) {
 			StreamWrap:        true,
 			StreamWrapHandler: "handle_demo",
 			StreamWrapFields:  []string{"event", "data"},
-			StreamKeyword:     true,
 		},
 	}
 
 	syncCode := pygen.RenderOperationMethod(doc, binding, false)
-	if !strings.Contains(syncCode, "response: IteratorHTTPResponse[str] = self._requester.request(\"post\", url, stream=True, cast=None, headers=headers)") {
-		t.Fatalf("expected keyword stream/cast request call:\n%s", syncCode)
+	if !strings.Contains(syncCode, "response: IteratorHTTPResponse[str] = self._requester.request(\"post\", url, True, cast=None, headers=headers)") {
+		t.Fatalf("expected stream bool request call:\n%s", syncCode)
 	}
 	if !strings.Contains(syncCode, "return Stream(") || !strings.Contains(syncCode, "handler=handle_demo") {
 		t.Fatalf("expected wrapped sync stream return:\n%s", syncCode)
 	}
 
 	asyncCode := pygen.RenderOperationMethod(doc, binding, true)
-	if !strings.Contains(asyncCode, "resp: AsyncIteratorHTTPResponse[str] = await self._requester.arequest(\"post\", url, stream=True, cast=None, headers=headers)") {
-		t.Fatalf("expected keyword async request call:\n%s", asyncCode)
+	if !strings.Contains(asyncCode, "resp: AsyncIteratorHTTPResponse[str] = await self._requester.arequest(\"post\", url, True, cast=None, headers=headers)") {
+		t.Fatalf("expected async stream bool request call:\n%s", asyncCode)
 	}
 	if !strings.Contains(asyncCode, "return AsyncStream(") || !strings.Contains(asyncCode, "raw_response=resp._raw_response") {
 		t.Fatalf("expected wrapped async stream return:\n%s", asyncCode)

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -473,7 +473,6 @@ func renderOperationMethodWithContext(
 	returnType, returnCast := ReturnTypeInfo(doc, details.ResponseSchema)
 	requestBodyType, bodyRequired := RequestBodyTypeInfo(doc, details.RequestBodySchema, details.RequestBody)
 	ignoreHeaderParams := binding.Mapping != nil && binding.Mapping.IgnoreHeaderParams
-	streamKeyword := binding.Mapping != nil && binding.Mapping.StreamKeyword
 	streamWrap := binding.Mapping != nil && binding.Mapping.StreamWrap
 	asyncIncludeKwargs := async && binding.Mapping != nil && binding.Mapping.AsyncIncludeKwargs
 	paginationCastBeforeHeaders := binding.Mapping != nil && binding.Mapping.PaginationCastBeforeHeaders
@@ -1377,11 +1376,7 @@ func renderOperationMethodWithContext(
 	if requestStream {
 		streamLiteral = "True"
 	}
-	streamExpr := streamLiteral
-	if streamKeyword {
-		streamExpr = fmt.Sprintf("stream=%s", streamLiteral)
-	}
-	optionalArgs = append(optionalArgs, requestCallArg{Expr: streamExpr})
+	optionalArgs = append(optionalArgs, requestCallArg{Expr: streamLiteral})
 	castExprValue := fmt.Sprintf("cast=%s", castExpr)
 	optionalArgs = append(optionalArgs, requestCallArg{Expr: castExprValue})
 	if len(queryFields) > 0 {


### PR DESCRIPTION
## Summary
- remove `stream_keyword` from `api.operation_mappings` in `config/generator.yaml`
- remove `StreamKeyword` from generator config parsing and Python operation rendering
- define the default behavior as a positional `stream` boolean argument in requester calls (`True` / `False`)

## Why
`stream_keyword` is a legacy compatibility switch for hand-written SDK method styles. This change removes one compatibility-only knob and keeps generation behavior deterministic with a single default call style.

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (total coverage: 83.0%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh` (go baseline diff count = 0)

## Downstream
- coze-py PR: https://github.com/coze-dev/coze-py/pull/393
