### PR TITLE
refactor(config): remove ignore_apis mechanism

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -5109,6 +5109,37 @@ api:
       force_multiline_signature: true
       response_type: Message
       response_cast: Message
+    - path: /v1/conversation/message/list
+      method: post
+      order: 841
+      sdk_methods:
+        - conversations_message._list_page
+      query_builder: raw
+      query_fields:
+        - name: conversation_id
+          type: str
+          required: true
+      body_builder: raw
+      body_fields:
+        - order
+        - chat_id
+        - before_id
+        - after_id
+        - limit
+      body_field_values:
+        before_id: before_id if before_id else None
+        after_id: after_id if after_id else None
+      arg_defaults:
+        order: '"desc"'
+        limit: "50"
+      arg_types:
+        order: str
+        chat_id: Optional[str]
+        before_id: Optional[str]
+        after_id: Optional[str]
+        limit: int
+      response_type: _PrivateListMessageResp
+      response_cast: _PrivateListMessageResp
     - path: /v1/conversations/{conversation_id}/messages/{message_id}/feedback
       method: post
       order: 88
@@ -5550,8 +5581,6 @@ api:
       response_cast: User
       allow_missing_in_swagger: true
   ignore_apis:
-    - path: /v1/conversation/message/list
-      method: post
   field_aliases:
     chat:
       custom_variables: custom_variables

--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -5549,7 +5549,6 @@ api:
       response_type: User
       response_cast: User
       allow_missing_in_swagger: true
-  ignore_apis:
   field_aliases:
     chat:
       custom_variables: custom_variables

--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -5109,37 +5109,6 @@ api:
       force_multiline_signature: true
       response_type: Message
       response_cast: Message
-    - path: /v1/conversation/message/list
-      method: post
-      order: 841
-      sdk_methods:
-        - conversations_message._list_page
-      query_builder: raw
-      query_fields:
-        - name: conversation_id
-          type: str
-          required: true
-      body_builder: raw
-      body_fields:
-        - order
-        - chat_id
-        - before_id
-        - after_id
-        - limit
-      body_field_values:
-        before_id: before_id if before_id else None
-        after_id: after_id if after_id else None
-      arg_defaults:
-        order: '"desc"'
-        limit: "50"
-      arg_types:
-        order: str
-        chat_id: Optional[str]
-        before_id: Optional[str]
-        after_id: Optional[str]
-        limit: int
-      response_type: _PrivateListMessageResp
-      response_cast: _PrivateListMessageResp
     - path: /v1/conversations/{conversation_id}/messages/{message_id}/feedback
       method: post
       order: 88

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,7 +63,6 @@ type CommentOverrides struct {
 type APIConfig struct {
 	Packages           []Package                    `yaml:"packages"`
 	OperationMappings  []OperationMapping           `yaml:"operation_mappings"`
-	IgnoreAPIs         []OperationRef               `yaml:"ignore_apis"`
 	GenerateOnlyMapped bool                         `yaml:"generate_only_mapped"`
 	FieldAliases       map[string]map[string]string `yaml:"field_aliases"`
 }
@@ -584,12 +583,6 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	for i, ref := range c.API.IgnoreAPIs {
-		if err := validateOperationRef(ref.Path, ref.Method, fmt.Sprintf("api.ignore_apis[%d]", i)); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -636,16 +629,6 @@ func (c *Config) DiffIgnorePathsForLanguage(language string) []string {
 		return append([]string(nil), defaults...)
 	}
 	return []string{".git"}
-}
-
-func (c *Config) IsIgnored(path string, method string) bool {
-	method = normalizeMethod(method)
-	for _, ref := range c.API.IgnoreAPIs {
-		if ref.Path == path && normalizeMethod(ref.Method) == method {
-			return true
-		}
-	}
-	return false
 }
 
 func (c *Config) FindOperationMappings(path string, method string) []OperationMapping {
@@ -715,9 +698,6 @@ func (c *Config) ValidateAgainstSwagger(doc *openapi.Document) ValidationReport 
 		for _, op := range c.API.OperationMappings {
 			report.MissingOperations = append(report.MissingOperations, OperationRef{Path: op.Path, Method: normalizeMethod(op.Method)})
 		}
-		for _, op := range c.API.IgnoreAPIs {
-			report.MissingOperations = append(report.MissingOperations, OperationRef{Path: op.Path, Method: normalizeMethod(op.Method)})
-		}
 		return report
 	}
 
@@ -732,16 +712,6 @@ func (c *Config) ValidateAgainstSwagger(doc *openapi.Document) ValidationReport 
 	}
 
 	for _, op := range c.API.OperationMappings {
-		method := normalizeMethod(op.Method)
-		if op.AllowMissingInSwagger {
-			continue
-		}
-		if !doc.HasOperation(method, op.Path) {
-			appendMissing(op.Path, method)
-		}
-	}
-
-	for _, op := range c.API.IgnoreAPIs {
 		method := normalizeMethod(op.Method)
 		if op.AllowMissingInSwagger {
 			continue

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -351,9 +351,11 @@ api:
 language: python
 output_sdk: out
 api:
-  ignore_apis:
+  operation_mappings:
     - path: /v3/chat
       method: bad
+      sdk_methods:
+        - chat.bad
 `,
 		},
 		{
@@ -468,13 +470,6 @@ func TestConfigHelpers(t *testing.T) {
 	cfg, err := Load(filepath.Join("testdata", "generator.yaml"))
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
-	}
-
-	if !cfg.IsIgnored("/v1/workspaces/{workspace_id}", "get") {
-		t.Fatal("expected operation to be ignored")
-	}
-	if cfg.IsIgnored("/v1/workspaces/{workspace_id}", "post") {
-		t.Fatal("did not expect post to be ignored")
 	}
 
 	mappings := cfg.FindOperationMappings("/v3/chat", "POST")

--- a/internal/config/testdata/generator.yaml
+++ b/internal/config/testdata/generator.yaml
@@ -22,9 +22,6 @@ api:
       method: post
       sdk_methods:
         - workflows.chat
-  ignore_apis:
-    - path: /v1/workspaces/{workspace_id}
-      method: get
   field_aliases:
     chat:
       bot_id: bot_id

--- a/internal/generator/go/api_templates.go
+++ b/internal/generator/go/api_templates.go
@@ -503,9 +503,6 @@ func buildGoSwaggerOperationBindings(cfg *config.Config, doc *openapi.Document, 
 
 	bindings := make([]goSwaggerOperationBinding, 0)
 	for _, mapping := range cfg.API.OperationMappings {
-		if cfg.IsIgnored(mapping.Path, mapping.Method) {
-			continue
-		}
 		details, hasDetails := resolveGoOperationDetails(doc, mapping)
 		for methodIndex, sdkMethod := range mapping.SDKMethods {
 			pkg, method, ok := parseGoSDKMethod(cfg, mapping.Path, sdkMethod)

--- a/internal/generator/go/generator.go
+++ b/internal/generator/go/generator.go
@@ -77,9 +77,6 @@ func buildGoOperationBindings(cfg *config.Config, doc *openapi.Document) []goOpe
 	seen := map[string]int{}
 
 	for _, details := range allOps {
-		if cfg.IsIgnored(details.Path, details.Method) {
-			continue
-		}
 		base := strings.TrimSpace(details.OperationID)
 		if base == "" {
 			base = pygen.DefaultMethodName(details.OperationID, details.Path, details.Method)

--- a/internal/generator/python/bindings.go
+++ b/internal/generator/python/bindings.go
@@ -39,9 +39,6 @@ func buildOperationBindings(cfg *config.Config, doc *openapi.Document) []Operati
 
 	for _, details := range allOps {
 		existingOps[strings.ToLower(details.Method)+" "+details.Path] = struct{}{}
-		if cfg.IsIgnored(details.Path, details.Method) {
-			continue
-		}
 
 		mappings := cfg.FindOperationMappings(details.Path, details.Method)
 		if cfg.API.GenerateOnlyMapped && len(mappings) == 0 {
@@ -94,9 +91,6 @@ func buildOperationBindings(cfg *config.Config, doc *openapi.Document) []Operati
 		}
 		key := strings.ToLower(strings.TrimSpace(mapping.Method)) + " " + strings.TrimSpace(mapping.Path)
 		if _, ok := existingOps[key]; ok {
-			continue
-		}
-		if cfg.IsIgnored(mapping.Path, mapping.Method) {
 			continue
 		}
 		if len(mapping.SDKMethods) == 0 {


### PR DESCRIPTION
## Summary
- remove `ignore_apis` mechanism entirely from `coze-sdk-gen`
- remove `api.ignore_apis` section from `config/generator.yaml`
- remove related config field, validation, and filter logic in both python/go generators

## Scope
- config schema/runtime:
  - deleted `APIConfig.IgnoreAPIs`
  - deleted `Config.IsIgnored(...)`
  - deleted `Validate`/`ValidateAgainstSwagger` handling for ignored operations
- generator behavior:
  - python binding builder no longer filters by ignore list
  - go operation binding/template builder no longer filters by ignore list
- tests/fixtures:
  - removed `ignore_apis` from config test fixture
  - adjusted config tests accordingly

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.1%)
- `./scripts/build.sh`
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-nodiff-Htzdms/coze-py --ci-check`
- `git -C /tmp/coze-py-nodiff-Htzdms/coze-py status --short` => empty (no diff)

## Downstream PR
- `coze-py` PR closed per latest requirement (`pysdk` must stay zero diff):
  - https://github.com/coze-dev/coze-py/pull/395
