### PR TITLE
refactor(codegen): remove pagination_http_method config support

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -5164,7 +5164,6 @@ api:
       pagination_total_field: total_count
       pagination_page_num_field: page_num
       pagination_page_size_field: page_size
-      pagination_http_method: get
     - path: /v1/datasets/{dataset_id}/images/{document_id}
       method: put
       order: 91

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -214,7 +214,6 @@ type OperationMapping struct {
 	ForceMultilineSignatureAsync   bool              `yaml:"force_multiline_signature_async"`
 	ForceMultilineRequestCall      bool              `yaml:"force_multiline_request_call"`
 	ForceMultilineRequestCallAsync bool              `yaml:"force_multiline_request_call_async"`
-	PaginationHTTPMethod           string            `yaml:"pagination_http_method"`
 	PaginationRequestArg           string            `yaml:"pagination_request_arg"`
 	PaginationInitPageTokenExpr    string            `yaml:"pagination_init_page_token_expr"`
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1164,7 +1164,7 @@ func TestRenderOperationMethodSingleItemMapsUseMultilineFormat(t *testing.T) {
 	}
 }
 
-func TestRenderOperationMethodPaginationQueryBuilderAndTokenOverrides(t *testing.T) {
+func TestRenderOperationMethodPaginationQueryBuilderAndTokenInitOverrides(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{
 		Path:   "/v1/workflows/{workflow_id}/versions",
@@ -1186,7 +1186,6 @@ func TestRenderOperationMethodPaginationQueryBuilderAndTokenOverrides(t *testing
 		PaginationPageTokenField:    "page_token",
 		PaginationPageSizeField:     "page_size",
 		PaginationInitPageTokenExpr: "page_token or \"\"",
-		PaginationHTTPMethod:        "get",
 	}
 
 	syncCode := pygen.RenderOperationMethod(doc, pygen.OperationBinding{
@@ -1195,8 +1194,8 @@ func TestRenderOperationMethodPaginationQueryBuilderAndTokenOverrides(t *testing
 		Details:     details,
 		Mapping:     mapping,
 	}, false)
-	if !strings.Contains(syncCode, "make_request(\n                \"get\",") {
-		t.Fatalf("expected custom pagination http method in sync request:\n%s", syncCode)
+	if !strings.Contains(syncCode, "make_request(\n                \"GET\",") {
+		t.Fatalf("expected pagination request to use operation http method in sync request:\n%s", syncCode)
 	}
 	if !strings.Contains(syncCode, "params=dump_exclude_none(") {
 		t.Fatalf("expected sync query builder override:\n%s", syncCode)
@@ -1214,8 +1213,8 @@ func TestRenderOperationMethodPaginationQueryBuilderAndTokenOverrides(t *testing
 		Details:     details,
 		Mapping:     mapping,
 	}, true)
-	if !strings.Contains(asyncCode, "amake_request(\n                \"get\",") {
-		t.Fatalf("expected custom pagination http method in async request:\n%s", asyncCode)
+	if !strings.Contains(asyncCode, "amake_request(\n                \"GET\",") {
+		t.Fatalf("expected pagination request to use operation http method in async request:\n%s", asyncCode)
 	}
 	if !strings.Contains(asyncCode, "params=dump_exclude_none(") {
 		t.Fatalf("expected async query builder to follow query_builder:\n%s", asyncCode)

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -894,11 +894,6 @@ func renderOperationMethodWithContext(
 	}
 	includePaginationHeaders := true
 	paginationRequestMethod := strings.ToUpper(requestMethod)
-	if binding.Mapping != nil {
-		if override := strings.TrimSpace(binding.Mapping.PaginationHTTPMethod); override != "" {
-			paginationRequestMethod = override
-		}
-	}
 
 	if isTokenPagination(paginationMode) && binding.Mapping != nil {
 		dataClass := strings.TrimSpace(binding.Mapping.PaginationDataClass)


### PR DESCRIPTION
## Summary
- Remove `api.operation_mappings[].pagination_http_method` from generator config schema and from `config/generator.yaml`.
- Remove pagination HTTP method override branch in Python operation renderer.
- Define the default pagination request method as the operation HTTP method (normalized to upper-case).
- Update generator tests to assert the new default behavior.

## Generator Impact
- Configuration surface is simplified by removing one legacy compatibility knob.
- Generated Python SDK no longer allows per-pagination method override.
- Current generated delta is limited to `datasets_images.list` request method literal (`"get"` -> `"GET"`).

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.0%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh` (zero diff)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-oQNWoq --ci-check`

## Downstream PR
- coze-py PR: https://github.com/coze-dev/coze-py/pull/396
