### PR TITLE
feat(codegen): remove http_method_override and default to mapping method

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -3688,7 +3688,6 @@ api:
       sdk_methods:
         - chat.retrieve
       force_multiline_signature: true
-      http_method_override: post
       query_builder: raw
       query_fields:
         - name: conversation_id
@@ -3822,7 +3821,6 @@ api:
       order: 30
       sdk_methods:
         - api_apps.delete
-      http_method_override: delete
       disable_request_body: true
       param_aliases:
         api_app_id: app_id
@@ -3833,7 +3831,6 @@ api:
       order: 40
       sdk_methods:
         - api_apps.list
-      http_method_override: get
       disable_request_body: true
       query_fields:
         - name: app_type
@@ -4600,7 +4597,6 @@ api:
         - folders.retrieve
       no_blank_line_after_headers: true
       force_multiline_signature: true
-      http_method_override: GET
       response_type: SimpleFolder
       response_cast: SimpleFolder
     - path: /v1/folders

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,7 +156,6 @@ type OperationMapping struct {
 	Order                          int               `yaml:"order"`
 	SDKMethods                     []string          `yaml:"sdk_methods"`
 	AllowMissingInSwagger          bool              `yaml:"allow_missing_in_swagger"`
-	HTTPMethodOverride             string            `yaml:"http_method_override"`
 	DisableRequestBody             bool              `yaml:"disable_request_body"`
 	BodyFields                     []string          `yaml:"body_fields"`
 	BodyFixedValues                map[string]string `yaml:"body_fixed_values"`
@@ -491,11 +490,6 @@ func (c *Config) Validate() error {
 	for i, mapping := range c.API.OperationMappings {
 		if err := validateOperationRef(mapping.Path, mapping.Method, fmt.Sprintf("api.operation_mappings[%d]", i)); err != nil {
 			return err
-		}
-		if strings.TrimSpace(mapping.HTTPMethodOverride) != "" {
-			if err := validateOperationRef(mapping.Path, mapping.HTTPMethodOverride, fmt.Sprintf("api.operation_mappings[%d].http_method_override", i)); err != nil {
-				return err
-			}
 		}
 		if len(mapping.SDKMethods) == 0 {
 			return fmt.Errorf("api.operation_mappings[%d].sdk_methods should not be empty", i)

--- a/internal/generator/go/api_templates.go
+++ b/internal/generator/go/api_templates.go
@@ -516,10 +516,7 @@ func buildGoSwaggerOperationBindings(cfg *config.Config, doc *openapi.Document, 
 			if goMethod == "" {
 				continue
 			}
-			httpMethod := strings.TrimSpace(mapping.HTTPMethodOverride)
-			if httpMethod == "" {
-				httpMethod = strings.TrimSpace(mapping.Method)
-			}
+			httpMethod := strings.TrimSpace(mapping.Method)
 			if httpMethod == "" {
 				httpMethod = http.MethodGet
 			}

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -226,10 +226,6 @@ func shouldSuppressSwaggerMethodDocstring(binding OperationBinding) bool {
 	if pagination == "token" || pagination == "number" {
 		return true
 	}
-	if methodOverride := strings.TrimSpace(binding.Mapping.HTTPMethodOverride); methodOverride != "" &&
-		strings.ToLower(methodOverride) != strings.ToLower(binding.Details.Method) {
-		return true
-	}
 	return false
 }
 
@@ -496,9 +492,6 @@ func renderOperationMethodWithContext(
 		argTypes = binding.Mapping.ArgTypes
 	}
 	if binding.Mapping != nil {
-		if methodOverride := strings.TrimSpace(binding.Mapping.HTTPMethodOverride); methodOverride != "" {
-			requestMethod = methodOverride
-		}
 		paginationMode = strings.TrimSpace(binding.Mapping.Pagination)
 		if isTokenPagination(paginationMode) || isNumberPagination(paginationMode) {
 			itemType := strings.TrimSpace(binding.Mapping.PaginationItemType)


### PR DESCRIPTION
## Summary
- remove `http_method_override` from codegen config schema and validation
- remove all `http_method_override` entries from `config/generator.yaml`
- define default behavior as: generated HTTP method always follows `operation_mappings[].method` (and Swagger operation method when not mapped)
- remove Python docstring suppression logic that was only needed for method override mismatches

## Behavior Changes
After this change, generated SDK methods no longer override HTTP method via config:
- `api_apps.delete`: `DELETE` -> `PUT`
- `api_apps.list`: `GET` -> `POST`
- `chat.retrieve`: `POST` -> `GET`
- `folders.retrieve`: `GET` (uppercase literal) -> `get` (normalized lowercase)

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (total coverage: 83.1%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh` (zero diff)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-e84vqO --ci-check`
  - poetry build / ruff / mypy passed
  - pytest: 285 passed

## Traceability


- downstream coze-py PR: https://github.com/coze-dev/coze-py/pull/397

