### PR TITLE
refactor(py): remove pagination_cast_before_headers config

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -3850,7 +3850,6 @@ api:
       pagination: token
       pagination_data_class: _PrivateListAPIAppsData
       pagination_item_type: APIApp
-      pagination_cast_before_headers: true
     - path: /v1/apps
       method: get
       order: 50
@@ -4692,7 +4691,6 @@ api:
       pagination_next_token_field: next_page_token
       pagination_page_token_field: page_token
       pagination_page_size_field: page_size
-      pagination_cast_before_headers: true
     - path: /v1/audio/rooms
       method: post
       order: 79

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -189,7 +189,6 @@ type OperationMapping struct {
 	PaginationPageNumField         string            `yaml:"pagination_page_num_field"`
 	PaginationPageSizeField        string            `yaml:"pagination_page_size_field"`
 	PaginationPageTokenField       string            `yaml:"pagination_page_token_field"`
-	PaginationCastBeforeHeaders    bool              `yaml:"pagination_cast_before_headers"`
 	AsyncIncludeKwargs             bool              `yaml:"async_include_kwargs"`
 	IgnoreHeaderParams             bool              `yaml:"ignore_header_params"`
 	DataField                      string            `yaml:"data_field"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1004,7 +1004,7 @@ func TestRenderOperationMethodAsyncStreamMethodDefaultsToYield(t *testing.T) {
 	}
 }
 
-func TestRenderOperationMethodPaginationOrderOptions(t *testing.T) {
+func TestRenderOperationMethodPaginationRequestOrder(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{
 		Path:   "/v1/apps",
@@ -1028,25 +1028,9 @@ func TestRenderOperationMethodPaginationOrderOptions(t *testing.T) {
 	}, false)
 	idxHeaders := strings.Index(codeHeadersFirst, "headers=headers")
 	idxParams := strings.Index(codeHeadersFirst, "params=")
-	if idxHeaders == -1 || idxParams == -1 || idxHeaders > idxParams {
-		t.Fatalf("expected headers before params in pagination request:\n%s", codeHeadersFirst)
-	}
-
-	codeCastBeforeHeaders := pygen.RenderOperationMethod(doc, pygen.OperationBinding{
-		PackageName: "apps",
-		MethodName:  "list",
-		Details:     details,
-		Mapping: &config.OperationMapping{
-			Pagination:                  "number",
-			PaginationDataClass:         "_PrivateListAppsData",
-			PaginationItemType:          "App",
-			PaginationCastBeforeHeaders: true,
-		},
-	}, false)
-	idxCast := strings.Index(codeCastBeforeHeaders, "cast=_PrivateListAppsData")
-	idxHeaders = strings.Index(codeCastBeforeHeaders, "headers=headers")
-	if idxCast == -1 || idxHeaders == -1 || idxCast > idxHeaders {
-		t.Fatalf("expected cast before headers in pagination request:\n%s", codeCastBeforeHeaders)
+	idxCast := strings.Index(codeHeadersFirst, "cast=_PrivateListAppsData")
+	if idxHeaders == -1 || idxParams == -1 || idxCast == -1 || idxHeaders > idxParams || idxParams > idxCast {
+		t.Fatalf("expected pagination request to keep fixed order headers -> params -> cast:\n%s", codeHeadersFirst)
 	}
 }
 

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -475,8 +475,6 @@ func renderOperationMethodWithContext(
 	ignoreHeaderParams := binding.Mapping != nil && binding.Mapping.IgnoreHeaderParams
 	streamWrap := binding.Mapping != nil && binding.Mapping.StreamWrap
 	asyncIncludeKwargs := async && binding.Mapping != nil && binding.Mapping.AsyncIncludeKwargs
-	paginationCastBeforeHeaders := binding.Mapping != nil && binding.Mapping.PaginationCastBeforeHeaders
-	headersBeforePaginationParams := !paginationCastBeforeHeaders
 	streamWrapHandler := ""
 	streamWrapFields := []string{}
 	streamWrapAsyncYield := false
@@ -929,7 +927,7 @@ func renderOperationMethodWithContext(
 			buf.WriteString("            return await self._requester.amake_request(\n")
 			buf.WriteString(fmt.Sprintf("                %q,\n", paginationRequestMethod))
 			buf.WriteString("                url,\n")
-			if headersBeforePaginationParams && includePaginationHeaders {
+			if includePaginationHeaders {
 				buf.WriteString("                headers=headers,\n")
 			}
 			if queryBuilder == "raw" {
@@ -961,19 +959,7 @@ func renderOperationMethodWithContext(
 				buf.WriteString("                    }\n")
 				buf.WriteString("                ),\n")
 			}
-			if includePaginationHeaders {
-				if paginationCastBeforeHeaders && !headersBeforePaginationParams {
-					buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-					buf.WriteString("                headers=headers,\n")
-				} else if headersBeforePaginationParams {
-					buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-				} else {
-					buf.WriteString("                headers=headers,\n")
-					buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-				}
-			} else {
-				buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-			}
+			buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
 			if dataField != "" {
 				buf.WriteString(fmt.Sprintf("                data_field=%q,\n", dataField))
 			}
@@ -990,7 +976,7 @@ func renderOperationMethodWithContext(
 			buf.WriteString("            return self._requester.make_request(\n")
 			buf.WriteString(fmt.Sprintf("                %q,\n", paginationRequestMethod))
 			buf.WriteString("                url,\n")
-			if headersBeforePaginationParams && includePaginationHeaders {
+			if includePaginationHeaders {
 				buf.WriteString("                headers=headers,\n")
 			}
 			if queryBuilder == "raw" {
@@ -1022,19 +1008,7 @@ func renderOperationMethodWithContext(
 				buf.WriteString("                    }\n")
 				buf.WriteString("                ),\n")
 			}
-			if includePaginationHeaders {
-				if paginationCastBeforeHeaders && !headersBeforePaginationParams {
-					buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-					buf.WriteString("                headers=headers,\n")
-				} else if headersBeforePaginationParams {
-					buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-				} else {
-					buf.WriteString("                headers=headers,\n")
-					buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-				}
-			} else {
-				buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-			}
+			buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
 			if dataField != "" {
 				buf.WriteString(fmt.Sprintf("                data_field=%q,\n", dataField))
 			}
@@ -1075,7 +1049,7 @@ func renderOperationMethodWithContext(
 			buf.WriteString("            return await self._requester.amake_request(\n")
 			buf.WriteString(fmt.Sprintf("                %q,\n", paginationRequestMethod))
 			buf.WriteString("                url,\n")
-			if headersBeforePaginationParams && includePaginationHeaders {
+			if includePaginationHeaders {
 				buf.WriteString("                headers=headers,\n")
 			}
 			if queryBuilder == "raw" {
@@ -1107,19 +1081,7 @@ func renderOperationMethodWithContext(
 				buf.WriteString("                    }\n")
 				buf.WriteString("                ),\n")
 			}
-			if includePaginationHeaders {
-				if paginationCastBeforeHeaders && !headersBeforePaginationParams {
-					buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-					buf.WriteString("                headers=headers,\n")
-				} else if headersBeforePaginationParams {
-					buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-				} else {
-					buf.WriteString("                headers=headers,\n")
-					buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-				}
-			} else {
-				buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-			}
+			buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
 			if dataField != "" {
 				buf.WriteString(fmt.Sprintf("                data_field=%q,\n", dataField))
 			}
@@ -1136,7 +1098,7 @@ func renderOperationMethodWithContext(
 			buf.WriteString("            return self._requester.make_request(\n")
 			buf.WriteString(fmt.Sprintf("                %q,\n", paginationRequestMethod))
 			buf.WriteString("                url,\n")
-			if headersBeforePaginationParams && includePaginationHeaders {
+			if includePaginationHeaders {
 				buf.WriteString("                headers=headers,\n")
 			}
 			if queryBuilder == "raw" {
@@ -1168,19 +1130,7 @@ func renderOperationMethodWithContext(
 				buf.WriteString("                    }\n")
 				buf.WriteString("                ),\n")
 			}
-			if includePaginationHeaders {
-				if paginationCastBeforeHeaders && !headersBeforePaginationParams {
-					buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-					buf.WriteString("                headers=headers,\n")
-				} else if headersBeforePaginationParams {
-					buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-				} else {
-					buf.WriteString("                headers=headers,\n")
-					buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-				}
-			} else {
-				buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
-			}
+			buf.WriteString(fmt.Sprintf("                cast=%s,\n", dataClass))
 			if dataField != "" {
 				buf.WriteString(fmt.Sprintf("                data_field=%q,\n", dataField))
 			}


### PR DESCRIPTION
## Summary
- remove `pagination_cast_before_headers` from `config/generator.yaml` and all operation mappings
- remove the corresponding `OperationMapping` field and pagination render branch in Python generator
- fix pagination request generation to a single default ordering: `headers -> params -> cast`
- update generator unit test to assert the fixed default order

## Validation
- ./scripts/fmt.sh
- ./scripts/lint.sh
- ./scripts/test.sh (Total coverage: 83.2%)
- ./scripts/build.sh
- ./scripts/gengo.sh --output-sdk /tmp/coze-go-generated-b7Aaq6 + diff check against /tmp/coze-go-KV6ScF (zero diff)
- ./scripts/genpy.sh --output-sdk /tmp/coze-py-TMbdRw --ci-check


## Downstream
- coze-py PR: https://github.com/coze-dev/coze-py/pull/398
