### PR TITLE
refactor(codegen): remove blank_line_after_docstring config support

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4022,7 +4022,6 @@ api:
       order: 62
       sdk_methods:
         - datasets.list
-      blank_line_after_docstring: true
       query_builder: raw
       query_fields:
         - name: space_id

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -208,7 +208,6 @@ type OperationMapping struct {
 	HeadersExpr                    string            `yaml:"headers_expr"`
 	BlankLineAfterHeaders          bool              `yaml:"blank_line_after_headers"`
 	NoBlankLineAfterHeaders        bool              `yaml:"no_blank_line_after_headers"`
-	BlankLineAfterDocstring        bool              `yaml:"blank_line_after_docstring"`
 	ForceMultilineSignature        bool              `yaml:"force_multiline_signature"`
 	ForceMultilineSignatureSync    bool              `yaml:"force_multiline_signature_sync"`
 	ForceMultilineSignatureAsync   bool              `yaml:"force_multiline_signature_async"`

--- a/internal/generator/generator_rendering_test.go
+++ b/internal/generator/generator_rendering_test.go
@@ -324,6 +324,30 @@ func TestRenderPackageModuleRichTextOverrideCollapsedLinesAreSplit(t *testing.T)
 	}
 }
 
+func TestRenderOperationMethodDocstringNoExtraBlankLineBeforeURL(t *testing.T) {
+	doc := mustParseSwagger(t)
+	binding := pygen.OperationBinding{
+		PackageName: "demo",
+		MethodName:  "retrieve",
+		Details: openapi.OperationDetails{
+			Path:        "/v1/demo/{id}",
+			Method:      "get",
+			Description: "Retrieve a demo resource.",
+			PathParameters: []openapi.ParameterSpec{
+				{Name: "id", In: "path", Required: true, Schema: &openapi.Schema{Type: "string"}},
+			},
+		},
+	}
+
+	code := pygen.RenderOperationMethod(doc, binding, false)
+	if !strings.Contains(code, "Retrieve a demo resource.") {
+		t.Fatalf("expected method docstring to be rendered:\n%s", code)
+	}
+	if strings.Contains(code, "\"\"\"\n\n        url =") {
+		t.Fatalf("did not expect extra blank line between docstring and url:\n%s", code)
+	}
+}
+
 func TestRenderOperationMethodBlankLineAfterHeaders(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -819,9 +819,6 @@ func renderOperationMethodWithContext(
 		RenderDelegatedCall(&buf, autoDelegateTo, callArgs, async, delegateAsyncYield)
 		return buf.String()
 	}
-	if binding.Mapping != nil && binding.Mapping.BlankLineAfterDocstring {
-		buf.WriteString("\n")
-	}
 
 	urlPath := details.Path
 	for rawName, pyName := range pathParamNameMap {


### PR DESCRIPTION
## Summary
- Remove `api.operation_mappings[].blank_line_after_docstring` from the generator mapping schema and `config/generator.yaml`.
- Remove the corresponding Python rendering branch that injected an extra blank line after method docstrings.
- Define default behavior as: method docstring ends and `url` assignment starts immediately on the next line.
- Add a rendering test to lock the new default behavior.

## Why This Config
- Not duplicated with currently open config-removal PRs (`http_method_override`, `pagination_cast_before_headers`, `ignore_apis`).
- This option is a low-frequency legacy formatting compatibility switch (single config usage) and safe to remove incrementally.

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.0%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh` (zero diff)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-oQNWoq --ci-check`

## Downstream PR
- coze-py PR: https://github.com/coze-dev/coze-py/pull/399
