### PR TITLE
refactor(py): remove force_multiline_signature_async config

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4422,7 +4422,6 @@ api:
       order: 68
       sdk_methods:
         - bots.publish
-      force_multiline_signature_async: true
       body_builder: raw
       pre_body_code:
         - |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,7 +211,6 @@ type OperationMapping struct {
 	BlankLineAfterDocstring        bool              `yaml:"blank_line_after_docstring"`
 	ForceMultilineSignature        bool              `yaml:"force_multiline_signature"`
 	ForceMultilineSignatureSync    bool              `yaml:"force_multiline_signature_sync"`
-	ForceMultilineSignatureAsync   bool              `yaml:"force_multiline_signature_async"`
 	ForceMultilineRequestCall      bool              `yaml:"force_multiline_request_call"`
 	ForceMultilineRequestCallAsync bool              `yaml:"force_multiline_request_call_async"`
 	PaginationRequestArg           string            `yaml:"pagination_request_arg"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -951,6 +951,55 @@ func TestRenderOperationMethodSignatureThresholdByNonKwargs(t *testing.T) {
 	}
 }
 
+func TestRenderOperationMethodAsyncSignatureThresholdByNonKwargs(t *testing.T) {
+	doc := mustParseSwagger(t)
+	baseBinding := pygen.OperationBinding{
+		PackageName: "demo",
+		Mapping:     &config.OperationMapping{},
+	}
+
+	twoArgsCode := pygen.RenderOperationMethod(doc, pygen.OperationBinding{
+		PackageName: baseBinding.PackageName,
+		MethodName:  "list_two",
+		Mapping:     baseBinding.Mapping,
+		Details: openapi.OperationDetails{
+			Path:   "/v1/demo",
+			Method: "get",
+			QueryParameters: []openapi.ParameterSpec{
+				{Name: "a", In: "query", Required: true, Schema: &openapi.Schema{Type: "string"}},
+				{Name: "b", In: "query", Required: true, Schema: &openapi.Schema{Type: "string"}},
+			},
+		},
+	}, true)
+	if !strings.Contains(twoArgsCode, "async def list_two(self, *, a: str, b: str, **kwargs)") {
+		t.Fatalf("expected compact async signature when non-kwargs args <= 2:\n%s", twoArgsCode)
+	}
+	if strings.Contains(twoArgsCode, "async def list_two(\n") {
+		t.Fatalf("did not expect multiline async signature when non-kwargs args <= 2:\n%s", twoArgsCode)
+	}
+
+	threeArgsCode := pygen.RenderOperationMethod(doc, pygen.OperationBinding{
+		PackageName: baseBinding.PackageName,
+		MethodName:  "list_three",
+		Mapping:     baseBinding.Mapping,
+		Details: openapi.OperationDetails{
+			Path:   "/v1/demo",
+			Method: "get",
+			QueryParameters: []openapi.ParameterSpec{
+				{Name: "a", In: "query", Required: true, Schema: &openapi.Schema{Type: "string"}},
+				{Name: "b", In: "query", Required: true, Schema: &openapi.Schema{Type: "string"}},
+				{Name: "c", In: "query", Required: true, Schema: &openapi.Schema{Type: "string"}},
+			},
+		},
+	}, true)
+	if !strings.Contains(threeArgsCode, "async def list_three(\n") {
+		t.Fatalf("expected multiline async signature when non-kwargs args > 2:\n%s", threeArgsCode)
+	}
+	if !strings.Contains(threeArgsCode, "        **kwargs,\n") {
+		t.Fatalf("expected kwargs preserved in multiline async signature:\n%s", threeArgsCode)
+	}
+}
+
 func TestRenderOperationMethodAsyncStreamMethodDefaultsToYield(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -748,11 +748,7 @@ func renderOperationMethodWithContext(
 		if binding.Mapping.ForceMultilineSignature {
 			compactSignature = false
 		}
-		if async {
-			if binding.Mapping.ForceMultilineSignatureAsync {
-				compactSignature = false
-			}
-		} else {
+		if !async {
 			if binding.Mapping.ForceMultilineSignatureSync {
 				compactSignature = false
 			}


### PR DESCRIPTION
## Summary
- remove the `force_multiline_signature_async` compatibility config from `config/generator.yaml`
- remove the corresponding `OperationMapping` field and renderer branch in Python codegen
- define the default behavior as a single signature strategy for sync/async methods:
  - non-kwargs args `<= 2` => compact signature
  - non-kwargs args `> 2` => multiline signature
- add async signature-threshold coverage in `internal/generator/generator_test.go`

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (total coverage: `83.0%`)
- `./scripts/build.sh`
- `./scripts/gengo.sh --output-sdk exist-repo/coze-go-generated`
- `./scripts/diffgo.sh` (no diff output)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-4bOijq --ci-check`

## Traceability
- downstream `coze-py` PR: https://github.com/coze-dev/coze-py/pull/400
