### PR TITLE
refactor(codegen): remove blank_line_after_headers config support

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4102,7 +4102,6 @@ api:
         connector_id: str
         audit_status: Optional[AuditStatus]
         reason: Optional[str]
-      blank_line_after_headers: true
       response_type: UpdateConnectorBotResp
       response_cast: UpdateConnectorBotResp
     - path: /v1/connectors/{connector_id}/user_configs

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,7 +206,6 @@ type OperationMapping struct {
 	BodyCallExpr                   string            `yaml:"body_call_expr"`
 	BodyFieldValues                map[string]string `yaml:"body_field_values"`
 	HeadersExpr                    string            `yaml:"headers_expr"`
-	BlankLineAfterHeaders          bool              `yaml:"blank_line_after_headers"`
 	NoBlankLineAfterHeaders        bool              `yaml:"no_blank_line_after_headers"`
 	ForceMultilineSignature        bool              `yaml:"force_multiline_signature"`
 	ForceMultilineSignatureSync    bool              `yaml:"force_multiline_signature_sync"`

--- a/internal/generator/generator_rendering_test.go
+++ b/internal/generator/generator_rendering_test.go
@@ -348,7 +348,7 @@ func TestRenderOperationMethodDocstringNoExtraBlankLineBeforeURL(t *testing.T) {
 	}
 }
 
-func TestRenderOperationMethodBlankLineAfterHeaders(t *testing.T) {
+func TestRenderOperationMethodHeadersDoNotForceBlankLine(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{
 		Path:   "/v1/demo/{id}",
@@ -369,9 +369,8 @@ func TestRenderOperationMethodBlankLineAfterHeaders(t *testing.T) {
 		MethodName:  "update",
 		Details:     details,
 		Mapping: &config.OperationMapping{
-			BodyBuilder:           "raw",
-			BodyFields:            []string{"name"},
-			BlankLineAfterHeaders: true,
+			BodyBuilder: "raw",
+			BodyFields:  []string{"name"},
 			ArgTypes: map[string]string{
 				"id":   "str",
 				"name": "str",
@@ -380,8 +379,8 @@ func TestRenderOperationMethodBlankLineAfterHeaders(t *testing.T) {
 	}
 
 	code := pygen.RenderOperationMethod(doc, binding, false)
-	if !strings.Contains(code, "headers: Optional[dict] = kwargs.get(\"headers\")\n\n        body = {") {
-		t.Fatalf("expected blank line between headers assignment and body when blank_line_after_headers=true:\n%s", code)
+	if strings.Contains(code, "headers: Optional[dict] = kwargs.get(\"headers\")\n\n        body = {") {
+		t.Fatalf("did not expect forced blank line between headers assignment and body:\n%s", code)
 	}
 }
 

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -1189,11 +1189,7 @@ func renderOperationMethodWithContext(
 	}
 
 	if headersExpr == "" && includeKwargsHeaders && !isTokenPagination(paginationMode) && !isNumberPagination(paginationMode) && len(details.HeaderParameters) == 0 {
-		if binding.Mapping != nil && binding.Mapping.BlankLineAfterHeaders {
-			buf.WriteString("        headers: Optional[dict] = kwargs.get(\"headers\")\n\n")
-		} else {
-			buf.WriteString("        headers: Optional[dict] = kwargs.get(\"headers\")\n")
-		}
+		buf.WriteString("        headers: Optional[dict] = kwargs.get(\"headers\")\n")
 		headersAssigned = true
 	}
 	if binding.Mapping != nil && len(binding.Mapping.PreBodyCode) > 0 {


### PR DESCRIPTION
## Summary
- Remove `api.operation_mappings[].blank_line_after_headers` from generator schema and `config/generator.yaml`.
- Remove the corresponding Python rendering branch that injected an extra blank line immediately after `headers = kwargs.get("headers")`.
- Define default behavior as: no forced extra blank line after the first headers assignment path.
- Keep existing `no_blank_line_after_headers` behavior unchanged.
- Update rendering test to lock the new default behavior.

## Non-overlap With Existing Open PRs
- This PR does **not** overlap with currently open config-removal tracks:
  - `http_method_override`
  - `pagination_cast_before_headers`
  - `ignore_apis`
  - `force_multiline_signature_async`

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.0%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh` (zero diff)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-oQNWoq --ci-check`

## Downstream PR
- coze-py PR: https://github.com/coze-dev/coze-py/pull/401
