### PR TITLE
refactor(py): infer response_type and response_cast for unwrap mappings

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -5336,8 +5336,6 @@ api:
       order: 93
       sdk_methods:
         - workflows_runs_run_histories.retrieve
-      response_type: WorkflowRunHistory
-      response_cast: ListResponse[WorkflowRunHistory]
       response_unwrap_list_first: true
     - path: /v1/workflows/{workflow_id}/run_histories/{execute_id}/execute_nodes/{node_execute_uuid}
       method: get

--- a/internal/generator/python/bindings.go
+++ b/internal/generator/python/bindings.go
@@ -64,8 +64,10 @@ func buildOperationBindings(cfg *config.Config, doc *openapi.Document) []Operati
 					if mappingCopy.Order > 0 {
 						order = mappingCopy.Order + methodIndex
 					}
+					pkgCopy := pkg
 					bindings = append(bindings, OperationBinding{
 						PackageName: NormalizePackageName(pkg.Name),
+						Package:     &pkgCopy,
 						MethodName:  NormalizeMethodName(methodName),
 						Details:     details,
 						Mapping:     &mappingCopy,
@@ -80,8 +82,10 @@ func buildOperationBindings(cfg *config.Config, doc *openapi.Document) []Operati
 		if !ok {
 			continue
 		}
+		pkgCopy := pkg
 		bindings = append(bindings, OperationBinding{
 			PackageName: NormalizePackageName(pkg.Name),
+			Package:     &pkgCopy,
 			MethodName:  DefaultMethodName(details.OperationID, details.Path, details.Method),
 			Details:     details,
 			Order:       len(bindings),
@@ -117,8 +121,10 @@ func buildOperationBindings(cfg *config.Config, doc *openapi.Document) []Operati
 			if mappingCopy.Order > 0 {
 				order = mappingCopy.Order + methodIndex
 			}
+			pkgCopy := pkg
 			bindings = append(bindings, OperationBinding{
 				PackageName: NormalizePackageName(pkg.Name),
+				Package:     &pkgCopy,
 				MethodName:  NormalizeMethodName(methodName),
 				Details:     details,
 				Mapping:     &mappingCopy,

--- a/internal/generator/python/generator.go
+++ b/internal/generator/python/generator.go
@@ -15,6 +15,7 @@ import (
 
 type OperationBinding struct {
 	PackageName string
+	Package     *config.Package
 	MethodName  string
 	Details     openapi.OperationDetails
 	Mapping     *config.OperationMapping


### PR DESCRIPTION
## Summary
- keep `response_unwrap_list_first: true` behavior and remove explicit mapping config at `/v1/workflows/{workflow_id}/run_histories/{execute_id}`:
  - remove `response_type: WorkflowRunHistory`
  - remove `response_cast: ListResponse[WorkflowRunHistory]`
- add generator-side automatic inference for unwrap mappings:
  - infer item model from `data` array response schema
  - respect package `model_schemas` renames (for example `WorkflowExecuteHistory -> WorkflowRunHistory`)
  - auto infer `response_cast = ListResponse[<InferredModel>]` when `response_unwrap_list_first=true` and response type/cast are omitted
- keep generated runtime logic unchanged for unwrap mode (`res.data[0]` + `_raw_response` propagation)
- add/adjust unit tests for unwrap inference behavior

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 82.5%)
- `./scripts/build.sh`
- Go baseline check:
  - `./scripts/gengo.sh --output-sdk /tmp/coze-go-generated-EwnFEK`
  - diff vs `/tmp/coze-go-LHyczd`: zero diff
- PySDK zero-diff check for this change:
  - generated SDK from `origin/main` worktree and this branch into two temp dirs
  - diff result: `DIFF_COUNT=0`

## Downstream
- No downstream `coze-py` code change is needed for this item (zero diff).
