### PR TITLE
refactor(codegen): remove body_call_expr config support

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -5238,7 +5238,7 @@ api:
       order: 90
       sdk_methods:
         - workflows_runs.create
-      body_builder: raw
+      body_builder: remove_none_values
       body_fields:
         - workflow_id
         - parameters
@@ -5258,7 +5258,6 @@ api:
         ext: Dict[str, Any]
       arg_defaults:
         is_async: "False"
-      body_call_expr: remove_none_values(body)
       response_type: WorkflowRunResult
       response_cast: WorkflowRunResult
     - path: /v1/workflow/stream_run
@@ -5266,7 +5265,7 @@ api:
       order: 91
       sdk_methods:
         - workflows_runs.stream
-      body_builder: raw
+      body_builder: remove_none_values
       body_fields:
         - workflow_id
         - parameters
@@ -5281,7 +5280,6 @@ api:
         bot_id: str
         app_id: str
         ext: Dict[str, Any]
-      body_call_expr: remove_none_values(body)
       request_stream: true
       stream_wrap: true
       stream_wrap_handler: _workflow_stream_handler

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,7 +201,6 @@ type OperationMapping struct {
 	StreamWrapCompactAsyncReturn   bool              `yaml:"stream_wrap_compact_async_return"`
 	StreamWrapCompactSyncReturn    bool              `yaml:"stream_wrap_compact_sync_return"`
 	QueryBuilder                   string            `yaml:"query_builder"`
-	BodyCallExpr                   string            `yaml:"body_call_expr"`
 	BodyFieldValues                map[string]string `yaml:"body_field_values"`
 	HeadersExpr                    string            `yaml:"headers_expr"`
 	BlankLineAfterHeaders          bool              `yaml:"blank_line_after_headers"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1116,7 +1116,7 @@ func TestRenderOperationMethodPreBodyCode(t *testing.T) {
 	}
 }
 
-func TestRenderOperationMethodBodyCallExprOverride(t *testing.T) {
+func TestRenderOperationMethodBodyBuilderRawUsesBodyDirectly(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{
 		Path:   "/v1/workflow/run",
@@ -1134,14 +1134,13 @@ func TestRenderOperationMethodBodyCallExprOverride(t *testing.T) {
 				"workflow_id": "str",
 				"parameters":  "Dict[str, Any]",
 			},
-			BodyCallExpr: "remove_none_values(body)",
 		},
 	}, false)
 	if !strings.Contains(code, "body = {") {
 		t.Fatalf("expected raw body map assignment:\n%s", code)
 	}
-	if !strings.Contains(code, "body=remove_none_values(body)") {
-		t.Fatalf("expected body call expression override in request call:\n%s", code)
+	if !strings.Contains(code, "body=body") {
+		t.Fatalf("expected request call to pass raw body directly:\n%s", code)
 	}
 }
 

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -484,7 +484,6 @@ func renderOperationMethodWithContext(
 	bodyFieldValues := map[string]string{}
 	paramAliases := map[string]string{}
 	argTypes := map[string]string{}
-	bodyCallExprOverride := ""
 	headersExpr := ""
 	paginationRequestArg := "params"
 	if binding.Mapping != nil && len(binding.Mapping.ParamAliases) > 0 {
@@ -549,7 +548,6 @@ func renderOperationMethodWithContext(
 		}
 		streamWrapCompactAsyncReturn = binding.Mapping.StreamWrapCompactAsyncReturn
 		streamWrapCompactSyncReturn = binding.Mapping.StreamWrapCompactSyncReturn
-		bodyCallExprOverride = strings.TrimSpace(binding.Mapping.BodyCallExpr)
 		headersExpr = strings.TrimSpace(binding.Mapping.HeadersExpr)
 		if override := strings.TrimSpace(binding.Mapping.PaginationRequestArg); override != "" {
 			paginationRequestArg = override
@@ -1325,15 +1323,7 @@ func renderOperationMethodWithContext(
 		optionalArgs = append(optionalArgs, requestCallArg{Expr: "headers=headers"})
 	}
 	if bodyArgExpr != "" {
-		bodyExpr := bodyArgExpr
-		if bodyCallExprOverride != "" {
-			if strings.Contains(bodyCallExprOverride, "{body}") {
-				bodyExpr = strings.ReplaceAll(bodyCallExprOverride, "{body}", bodyArgExpr)
-			} else {
-				bodyExpr = bodyCallExprOverride
-			}
-		}
-		optionalArgs = append(optionalArgs, requestCallArg{Expr: fmt.Sprintf("body=%s", bodyExpr)})
+		optionalArgs = append(optionalArgs, requestCallArg{Expr: fmt.Sprintf("body=%s", bodyArgExpr)})
 	}
 	if filesExpr != "" || len(filesFieldNames) > 0 {
 		optionalArgs = append(optionalArgs, requestCallArg{Expr: "files=files"})


### PR DESCRIPTION
## Summary
- remove `body_call_expr` config field from `OperationMapping`
- remove `body_call_expr` rendering logic from Python operation generator
- remove `body_call_expr` entries from `config/generator.yaml`
- switch the two affected workflow run mappings to `body_builder: remove_none_values`

## Default Behavior After Removal
`body_call_expr` is no longer supported. Body generation now follows `body_builder` only:
- `raw`: build plain dict and pass `body=body`
- `dump_exclude_none` / `remove_none_values`: build via selected builder and pass `body=body`

## Scope Control / Non-duplication
Checked existing PRs and avoided already-handled config removals (e.g. `pagination_http_method`, `blank_line_after_docstring`, `force_multiline_signature_async`, `blank_line_after_headers`).
This PR only targets `body_call_expr`.

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (coverage 83.2%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh` (zero diff)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-EEhSjK --ci-check`
  - poetry build passed
  - ruff check / format check passed
  - mypy passed
  - pytest passed (285 passed)

## Traceability

- downstream coze-py PR: https://github.com/coze-dev/coze-py/pull/403
