### PR TITLE
refactor(py): remove force_multiline_signature config

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -3687,7 +3687,6 @@ api:
       order: 3
       sdk_methods:
         - chat.retrieve
-      force_multiline_signature: true
       http_method_override: post
       query_builder: raw
       query_fields:
@@ -3704,7 +3703,6 @@ api:
       order: 4
       sdk_methods:
         - chat_message.list
-      force_multiline_signature: true
       query_builder: raw
       query_fields:
         - name: conversation_id
@@ -4067,7 +4065,6 @@ api:
       order: 64
       sdk_methods:
         - datasets.delete
-      force_multiline_signature: true
       force_multiline_request_call: true
       allow_missing_in_swagger: true
       disable_request_body: true
@@ -4596,7 +4593,6 @@ api:
       sdk_methods:
         - folders.retrieve
       no_blank_line_after_headers: true
-      force_multiline_signature: true
       http_method_override: GET
       response_type: SimpleFolder
       response_cast: SimpleFolder
@@ -4750,7 +4746,6 @@ api:
       order: 81
       sdk_methods:
         - audio_transcriptions.create
-      force_multiline_signature: true
       disable_request_body: true
       files_fields:
         - file
@@ -4767,7 +4762,6 @@ api:
         - audio_live.retrieve
       allow_missing_in_swagger: true
       disable_request_body: true
-      force_multiline_signature: true
       response_type: LiveInfo
       response_cast: LiveInfo
     - path: /v1/audio/voiceprint_groups
@@ -4785,7 +4779,6 @@ api:
       arg_types:
         name: str
         desc: str
-      force_multiline_signature: true
       response_type: CreateVoicePrintGroupResp
       response_cast: CreateVoicePrintGroupResp
     - path: /v1/audio/voiceprint_groups/{group_id}
@@ -4802,7 +4795,6 @@ api:
         group_id: str
         name: str
         desc: str
-      force_multiline_signature: true
       response_type: UpdateVoicePrintGroupResp
       response_cast: UpdateVoicePrintGroupResp
     - path: /v1/audio/voiceprint_groups/{group_id}
@@ -4812,7 +4804,6 @@ api:
         - audio_voiceprint_groups.delete
       allow_missing_in_swagger: true
       disable_request_body: true
-      force_multiline_signature: true
       response_type: DeleteVoicePrintGroupResp
       response_cast: DeleteVoicePrintGroupResp
     - path: /v1/audio/voiceprint_groups
@@ -4875,7 +4866,6 @@ api:
         sample_rate: int
         channel: int
       files_before_body: true
-      force_multiline_signature: true
       response_type: SpeakerIdentifyResp
       response_cast: SpeakerIdentifyResp
     - path: /v1/audio/voiceprint_groups/{group_id}/features
@@ -4905,7 +4895,6 @@ api:
         sample_rate: int
         channel: int
       files_before_body: true
-      force_multiline_signature: true
       response_type: CreateVoicePrintGroupFeatureResp
       response_cast: CreateVoicePrintGroupFeatureResp
     - path: /v1/audio/voiceprint_groups/{group_id}/features/{feature_id}
@@ -4932,7 +4921,6 @@ api:
         sample_rate: int
         channel: int
       files_before_body: true
-      force_multiline_signature: true
       response_type: UpdateVoicePrintGroupFeatureResp
       response_cast: UpdateVoicePrintGroupFeatureResp
     - path: /v1/audio/voiceprint_groups/{group_id}/features/{feature_id}
@@ -4942,7 +4930,6 @@ api:
         - audio_voiceprint_groups_features.delete
       allow_missing_in_swagger: true
       disable_request_body: true
-      force_multiline_signature: true
       response_type: DeleteVoicePrintGroupFeatureResp
       response_cast: DeleteVoicePrintGroupFeatureResp
     - path: /v1/audio/voiceprint_groups/{group_id}/features
@@ -5074,7 +5061,6 @@ api:
         - conversations_message.delete
       query_builder: raw
       disable_request_body: true
-      force_multiline_signature: true
       response_type: Message
       response_cast: Message
     - path: /v1/conversation/message/modify
@@ -5102,7 +5088,6 @@ api:
         - conversations_message.retrieve
       query_builder: raw
       disable_request_body: true
-      force_multiline_signature: true
       response_type: Message
       response_cast: Message
     - path: /v1/conversations/{conversation_id}/messages/{message_id}/feedback

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,7 +206,6 @@ type OperationMapping struct {
 	HeadersExpr                    string            `yaml:"headers_expr"`
 	BlankLineAfterHeaders          bool              `yaml:"blank_line_after_headers"`
 	NoBlankLineAfterHeaders        bool              `yaml:"no_blank_line_after_headers"`
-	ForceMultilineSignature        bool              `yaml:"force_multiline_signature"`
 	ForceMultilineSignatureSync    bool              `yaml:"force_multiline_signature_sync"`
 	ForceMultilineRequestCall      bool              `yaml:"force_multiline_request_call"`
 	ForceMultilineRequestCallAsync bool              `yaml:"force_multiline_request_call_async"`

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -743,9 +743,6 @@ func renderOperationMethodWithContext(
 	}
 	compactSignature := nonKwargsSignatureArgCount <= 2
 	if binding.Mapping != nil {
-		if binding.Mapping.ForceMultilineSignature {
-			compactSignature = false
-		}
 		if !async {
 			if binding.Mapping.ForceMultilineSignatureSync {
 				compactSignature = false


### PR DESCRIPTION
## Summary
- remove `force_multiline_signature` compatibility config from `generator.yaml`
- remove corresponding `OperationMapping` field and Python renderer branch
- define default behavior as unified signature threshold rule for both sync/async methods:
  - non-kwargs args `<= 2` => compact signature
  - non-kwargs args `> 2` => multiline signature

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (total coverage: `83.2%`)
- `./scripts/build.sh`
- `./scripts/gengo.sh --output-sdk exist-repo/coze-go-generated`
- `./scripts/diffgo.sh` (no diff output)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-zsEyqr --ci-check`

## Traceability
- downstream `coze-py` PR: https://github.com/coze-dev/coze-py/pull/404
