### PR TITLE
feat(codegen): remove disable_request_body config

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -3759,7 +3759,6 @@ api:
       order: 734
       sdk_methods:
         - benefits.retrieve
-      disable_request_body: true
       query_builder: remove_none_values
       query_fields:
         - name: benefit_type_list
@@ -3821,7 +3820,6 @@ api:
       sdk_methods:
         - api_apps.delete
       http_method_override: delete
-      disable_request_body: true
       param_aliases:
         api_app_id: app_id
       response_type: DeleteAPIAppsResp
@@ -3832,7 +3830,6 @@ api:
       sdk_methods:
         - api_apps.list
       http_method_override: get
-      disable_request_body: true
       query_fields:
         - name: app_type
           type: AppType
@@ -3904,7 +3901,6 @@ api:
       order: 52
       sdk_methods:
         - apps_collaborators.delete
-      disable_request_body: true
       response_type: RemoveAppCollaboratorResp
       response_cast: RemoveAppCollaboratorResp
     - path: /v1/conversation/create
@@ -3962,7 +3958,6 @@ api:
       order: 58
       sdk_methods:
         - conversations.clear
-      disable_request_body: true
       response_type: Section
       response_cast: Section
     - path: /v1/conversations/{conversation_id}
@@ -3983,7 +3978,6 @@ api:
       sdk_methods:
         - conversations.delete
       allow_missing_in_swagger: true
-      disable_request_body: true
       response_type: DeleteConversationResp
       response_cast: DeleteConversationResp
     - path: /v1/datasets
@@ -4067,7 +4061,6 @@ api:
         - datasets.delete
       force_multiline_request_call: true
       allow_missing_in_swagger: true
-      disable_request_body: true
       response_type: DeleteDatasetRes
       response_cast: DeleteDatasetRes
     - path: /v1/datasets/{dataset_id}/process
@@ -4206,7 +4199,6 @@ api:
       order: 656
       sdk_methods:
         - datasets_documents.list
-      disable_request_body: true
       query_builder: raw
       ignore_header_params: true
       headers_expr: '{"Agw-Js-Conv": "str"}'
@@ -4326,7 +4318,6 @@ api:
       order: 663
       sdk_methods:
         - knowledge_documents.list
-      disable_request_body: true
       query_builder: raw
       ignore_header_params: true
       headers_expr: '{"Agw-Js-Conv": "str"}'
@@ -4554,7 +4545,6 @@ api:
       order: 733
       sdk_methods:
         - bots_collaborators.delete
-      disable_request_body: true
       response_type: DeleteBotCollaboratorResp
       response_cast: DeleteBotCollaboratorResp
     - path: /v1/bots/{bot_id}/versions
@@ -4745,7 +4735,7 @@ api:
       order: 81
       sdk_methods:
         - audio_transcriptions.create
-      disable_request_body: true
+      force_multiline_signature: true
       files_fields:
         - file
       files_field_values:
@@ -4760,7 +4750,7 @@ api:
       sdk_methods:
         - audio_live.retrieve
       allow_missing_in_swagger: true
-      disable_request_body: true
+      force_multiline_signature: true
       response_type: LiveInfo
       response_cast: LiveInfo
     - path: /v1/audio/voiceprint_groups
@@ -4802,7 +4792,7 @@ api:
       sdk_methods:
         - audio_voiceprint_groups.delete
       allow_missing_in_swagger: true
-      disable_request_body: true
+      force_multiline_signature: true
       response_type: DeleteVoicePrintGroupResp
       response_cast: DeleteVoicePrintGroupResp
     - path: /v1/audio/voiceprint_groups
@@ -4928,7 +4918,7 @@ api:
       sdk_methods:
         - audio_voiceprint_groups_features.delete
       allow_missing_in_swagger: true
-      disable_request_body: true
+      force_multiline_signature: true
       response_type: DeleteVoicePrintGroupFeatureResp
       response_cast: DeleteVoicePrintGroupFeatureResp
     - path: /v1/audio/voiceprint_groups/{group_id}/features
@@ -5059,7 +5049,7 @@ api:
       sdk_methods:
         - conversations_message.delete
       query_builder: raw
-      disable_request_body: true
+      force_multiline_signature: true
       response_type: Message
       response_cast: Message
     - path: /v1/conversation/message/modify
@@ -5086,7 +5076,7 @@ api:
       sdk_methods:
         - conversations_message.retrieve
       query_builder: raw
-      disable_request_body: true
+      force_multiline_signature: true
       response_type: Message
       response_cast: Message
     - path: /v1/conversations/{conversation_id}/messages/{message_id}/feedback
@@ -5113,7 +5103,6 @@ api:
       order: 89
       sdk_methods:
         - conversations_message_feedback.delete
-      disable_request_body: true
       response_type: DeleteConversationMessageFeedbackResp
       response_cast: DeleteConversationMessageFeedbackResp
     - path: /v1/datasets/{dataset_id}/images
@@ -5359,7 +5348,6 @@ api:
       order: 951
       sdk_methods:
         - workflows_collaborators.delete
-      disable_request_body: true
       response_type: RemoveWorkflowCollaboratorResp
       response_cast: RemoveWorkflowCollaboratorResp
     - path: /v1/workflows/chat
@@ -5522,7 +5510,6 @@ api:
       method: get
       sdk_methods:
         - users.me
-      disable_request_body: true
       response_type: User
       response_cast: User
       allow_missing_in_swagger: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,7 +156,6 @@ type OperationMapping struct {
 	SDKMethods                     []string          `yaml:"sdk_methods"`
 	AllowMissingInSwagger          bool              `yaml:"allow_missing_in_swagger"`
 	HTTPMethodOverride             string            `yaml:"http_method_override"`
-	DisableRequestBody             bool              `yaml:"disable_request_body"`
 	BodyFields                     []string          `yaml:"body_fields"`
 	BodyFixedValues                map[string]string `yaml:"body_fixed_values"`
 	BodyBuilder                    string            `yaml:"body_builder"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -878,20 +878,21 @@ func TestRenderOperationMethodReturnAndAsyncKwargsOptions(t *testing.T) {
 	}
 }
 
-func TestRenderOperationMethodKwargsOnlySignature(t *testing.T) {
+func TestRenderOperationMethodKwargsOnlySignatureForEmptyBodySchema(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{
-		Path:   "/v1/users/me",
-		Method: "get",
+		Path:              "/v1/users/me",
+		Method:            "get",
+		RequestBody:       &openapi.RequestBody{},
+		RequestBodySchema: &openapi.Schema{Type: "object"},
 	}
 	code := pygen.RenderOperationMethod(doc, pygen.OperationBinding{
 		PackageName: "users",
 		MethodName:  "me",
 		Details:     details,
 		Mapping: &config.OperationMapping{
-			DisableRequestBody: true,
-			ResponseType:       "User",
-			ResponseCast:       "User",
+			ResponseType: "User",
+			ResponseCast: "User",
 		},
 	}, false)
 	if !strings.Contains(code, "def me(self, **kwargs)") {

--- a/internal/generator/python/generator.go
+++ b/internal/generator/python/generator.go
@@ -1251,13 +1251,9 @@ func packageNeedsAnyDict(doc *openapi.Document, bindings []OperationBinding, mod
 			}
 		}
 
-		if binding.Details.RequestBodySchema != nil {
-			disableRequestBody := mapping != nil && mapping.DisableRequestBody
-			hasBodyFields := mapping != nil && len(mapping.BodyFields) > 0
-			if !disableRequestBody && !hasBodyFields {
-				needAny = true
-				needDict = true
-			}
+		if shouldGenerateImplicitRequestBody(binding.Details.Method, mapping, binding.Details.RequestBodySchema) {
+			needAny = true
+			needDict = true
 		}
 
 		if mapping != nil {

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -609,11 +609,9 @@ func renderOperationMethodWithContext(
 		filesExpr = strings.TrimSpace(binding.Mapping.FilesExpr)
 		filesBeforeBody = binding.Mapping.FilesBeforeBody
 	}
-	if binding.Mapping != nil && binding.Mapping.DisableRequestBody {
+	if !shouldGenerateImplicitRequestBody(details.Method, binding.Mapping, details.RequestBodySchema) {
 		requestBodyType = ""
 		bodyRequired = false
-		bodyFieldNames = nil
-		bodyFixedValues = map[string]string{}
 	}
 	queryFields := buildRenderQueryFields(doc, details, binding.Mapping, paramAliases, argTypes)
 	signatureQueryFields := OrderSignatureQueryFields(queryFields, binding.Mapping, async)

--- a/internal/generator/python/request_body_policy.go
+++ b/internal/generator/python/request_body_policy.go
@@ -21,6 +21,9 @@ func shouldGenerateImplicitRequestBody(defaultMethod string, mapping *config.Ope
 	if isSafeWithoutBodyMethod(requestMethod) {
 		return false
 	}
+	if mapping != nil && len(mapping.QueryFields) > 0 {
+		return false
+	}
 	if hasExplicitPayloadConfig(mapping) {
 		return false
 	}

--- a/internal/generator/python/request_body_policy.go
+++ b/internal/generator/python/request_body_policy.go
@@ -1,0 +1,75 @@
+package python
+
+import (
+	"strings"
+
+	"github.com/coze-dev/coze-sdk-gen/internal/config"
+	"github.com/coze-dev/coze-sdk-gen/internal/openapi"
+)
+
+func shouldGenerateImplicitRequestBody(defaultMethod string, mapping *config.OperationMapping, requestBodySchema *openapi.Schema) bool {
+	if requestBodySchema == nil {
+		return false
+	}
+	requestMethod := strings.ToLower(strings.TrimSpace(defaultMethod))
+	if mapping != nil {
+		requestMethod = strings.ToLower(strings.TrimSpace(mapping.Method))
+		if override := strings.TrimSpace(mapping.HTTPMethodOverride); override != "" {
+			requestMethod = strings.ToLower(override)
+		}
+	}
+	if isSafeWithoutBodyMethod(requestMethod) {
+		return false
+	}
+	if mapping != nil && len(mapping.QueryFields) > 0 {
+		return false
+	}
+	if hasExplicitPayloadConfig(mapping) {
+		return false
+	}
+	return !isEffectivelyEmptyObjectSchema(requestBodySchema)
+}
+
+func hasExplicitPayloadConfig(mapping *config.OperationMapping) bool {
+	if mapping == nil {
+		return false
+	}
+	if len(mapping.BodyFields) > 0 || len(mapping.BodyFixedValues) > 0 {
+		return true
+	}
+	if len(mapping.FilesFields) > 0 || strings.TrimSpace(mapping.FilesExpr) != "" {
+		return true
+	}
+	return len(mapping.BodyFieldValues) > 0
+}
+
+func isEffectivelyEmptyObjectSchema(schema *openapi.Schema) bool {
+	if schema == nil {
+		return false
+	}
+	if len(schema.Properties) > 0 || len(schema.Required) > 0 {
+		return false
+	}
+	if schema.Items != nil || len(schema.AllOf) > 0 || len(schema.OneOf) > 0 || len(schema.AnyOf) > 0 {
+		return false
+	}
+	if len(schema.Enum) > 0 {
+		return false
+	}
+	if schema.AdditionalProperties != nil {
+		if allow, ok := schema.AdditionalProperties.(bool); !ok || allow {
+			return false
+		}
+	}
+	schemaType := strings.ToLower(strings.TrimSpace(schema.Type))
+	return schemaType == "" || schemaType == "object"
+}
+
+func isSafeWithoutBodyMethod(method string) bool {
+	switch strings.ToLower(strings.TrimSpace(method)) {
+	case "get", "delete", "head", "options", "trace":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/generator/python/request_body_policy.go
+++ b/internal/generator/python/request_body_policy.go
@@ -21,9 +21,6 @@ func shouldGenerateImplicitRequestBody(defaultMethod string, mapping *config.Ope
 	if isSafeWithoutBodyMethod(requestMethod) {
 		return false
 	}
-	if mapping != nil && len(mapping.QueryFields) > 0 {
-		return false
-	}
 	if hasExplicitPayloadConfig(mapping) {
 		return false
 	}

--- a/internal/generator/python/request_body_policy_test.go
+++ b/internal/generator/python/request_body_policy_test.go
@@ -1,0 +1,102 @@
+package python
+
+import (
+	"testing"
+
+	"github.com/coze-dev/coze-sdk-gen/internal/config"
+	"github.com/coze-dev/coze-sdk-gen/internal/openapi"
+)
+
+func TestShouldGenerateImplicitRequestBody(t *testing.T) {
+	t.Run("nil schema", func(t *testing.T) {
+		if shouldGenerateImplicitRequestBody("post", nil, nil) {
+			t.Fatal("expected false for nil schema")
+		}
+	})
+
+	t.Run("empty object schema", func(t *testing.T) {
+		schema := &openapi.Schema{Type: "object"}
+		if shouldGenerateImplicitRequestBody("post", nil, schema) {
+			t.Fatal("expected false for empty object schema")
+		}
+	})
+
+	t.Run("schema with properties", func(t *testing.T) {
+		schema := &openapi.Schema{
+			Type: "object",
+			Properties: map[string]*openapi.Schema{
+				"name": {Type: "string"},
+			},
+		}
+		if !shouldGenerateImplicitRequestBody("post", nil, schema) {
+			t.Fatal("expected true when schema has properties")
+		}
+	})
+
+	t.Run("primitive schema", func(t *testing.T) {
+		schema := &openapi.Schema{Type: "string"}
+		if !shouldGenerateImplicitRequestBody("post", nil, schema) {
+			t.Fatal("expected true for primitive request body schema")
+		}
+	})
+
+	t.Run("mapping body fields suppresses implicit body", func(t *testing.T) {
+		schema := &openapi.Schema{
+			Type: "object",
+			Properties: map[string]*openapi.Schema{
+				"name": {Type: "string"},
+			},
+		}
+		mapping := &config.OperationMapping{
+			BodyFields: []string{"name"},
+		}
+		if shouldGenerateImplicitRequestBody("post", mapping, schema) {
+			t.Fatal("expected false when body_fields is configured")
+		}
+	})
+
+	t.Run("mapping files fields suppresses implicit body", func(t *testing.T) {
+		schema := &openapi.Schema{
+			Type: "object",
+			Properties: map[string]*openapi.Schema{
+				"file": {Type: "string"},
+			},
+		}
+		mapping := &config.OperationMapping{
+			FilesFields: []string{"file"},
+		}
+		if shouldGenerateImplicitRequestBody("post", mapping, schema) {
+			t.Fatal("expected false when files_fields is configured")
+		}
+	})
+
+	t.Run("safe methods suppress implicit body", func(t *testing.T) {
+		schema := &openapi.Schema{
+			Type: "object",
+			Properties: map[string]*openapi.Schema{
+				"name": {Type: "string"},
+			},
+		}
+		if shouldGenerateImplicitRequestBody("get", nil, schema) {
+			t.Fatal("expected false for get method")
+		}
+	})
+
+	t.Run("query-only mapping suppresses implicit body", func(t *testing.T) {
+		schema := &openapi.Schema{
+			Type: "object",
+			Properties: map[string]*openapi.Schema{
+				"ignored": {Type: "string"},
+			},
+		}
+		mapping := &config.OperationMapping{
+			Method: "post",
+			QueryFields: []config.OperationField{
+				{Name: "cursor", Type: "str", Required: false},
+			},
+		}
+		if shouldGenerateImplicitRequestBody("post", mapping, schema) {
+			t.Fatal("expected false for query-only mapping")
+		}
+	})
+}

--- a/internal/generator/python/request_body_policy_test.go
+++ b/internal/generator/python/request_body_policy_test.go
@@ -82,7 +82,7 @@ func TestShouldGenerateImplicitRequestBody(t *testing.T) {
 		}
 	})
 
-	t.Run("query-only mapping suppresses implicit body", func(t *testing.T) {
+	t.Run("query-only mapping still allows implicit body on post", func(t *testing.T) {
 		schema := &openapi.Schema{
 			Type: "object",
 			Properties: map[string]*openapi.Schema{
@@ -95,8 +95,8 @@ func TestShouldGenerateImplicitRequestBody(t *testing.T) {
 				{Name: "cursor", Type: "str", Required: false},
 			},
 		}
-		if shouldGenerateImplicitRequestBody("post", mapping, schema) {
-			t.Fatal("expected false for query-only mapping")
+		if !shouldGenerateImplicitRequestBody("post", mapping, schema) {
+			t.Fatal("expected true for post query-only mapping with non-empty schema")
 		}
 	})
 }

--- a/internal/generator/python/request_body_policy_test.go
+++ b/internal/generator/python/request_body_policy_test.go
@@ -82,7 +82,7 @@ func TestShouldGenerateImplicitRequestBody(t *testing.T) {
 		}
 	})
 
-	t.Run("query-only mapping still allows implicit body on post", func(t *testing.T) {
+	t.Run("query-only mapping suppresses implicit body", func(t *testing.T) {
 		schema := &openapi.Schema{
 			Type: "object",
 			Properties: map[string]*openapi.Schema{
@@ -95,8 +95,8 @@ func TestShouldGenerateImplicitRequestBody(t *testing.T) {
 				{Name: "cursor", Type: "str", Required: false},
 			},
 		}
-		if !shouldGenerateImplicitRequestBody("post", mapping, schema) {
-			t.Fatal("expected true for post query-only mapping with non-empty schema")
+		if shouldGenerateImplicitRequestBody("post", mapping, schema) {
+			t.Fatal("expected false for query-only mapping")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- remove `disable_request_body` from generator config schema and from `config/generator.yaml`
- remove all code paths that depended on `disable_request_body`
- keep query-only mappings bodyless by default to preserve existing SDK surface
- add an automatic implicit-request-body policy as the default behavior

## New Default Behavior
- never generate implicit `body` arguments for safe methods (`GET`/`DELETE`/`HEAD`/`OPTIONS`/`TRACE`)
- never generate implicit `body` arguments when request payload is explicitly configured (`body_fields`/`body_fixed_values`/`files_fields`/`files_expr`/`body_field_values`)
- never generate implicit `body` arguments for query-only mappings
- never generate implicit `body` arguments for empty-object request body schemas
- otherwise, generate implicit `body` arguments from Swagger request body

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.2%)
- `./scripts/build.sh`
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-disable-body-zero-U67lpi/coze-py --ci-check`
  - poetry build / ruff / mypy / pytest all passed

## Downstream
- per latest requirement, no downstream coze-py change is kept for this task (previous PR #405 closed)
