### PR TITLE
refactor(codegen): remove pagination_init_page_token_expr config support

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -5370,7 +5370,6 @@ api:
       pagination_next_token_field: next_page_token
       pagination_page_token_field: page_token
       pagination_page_size_field: page_size
-      pagination_init_page_token_expr: page_token or ""
     - path: /v1/workflows/{workflow_id}/collaborators/{user_id}
       method: delete
       order: 951

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -210,7 +210,6 @@ type OperationMapping struct {
 	ForceMultilineRequestCall      bool              `yaml:"force_multiline_request_call"`
 	ForceMultilineRequestCallAsync bool              `yaml:"force_multiline_request_call_async"`
 	PaginationRequestArg           string            `yaml:"pagination_request_arg"`
-	PaginationInitPageTokenExpr    string            `yaml:"pagination_init_page_token_expr"`
 }
 
 type OperationField struct {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1197,7 +1197,7 @@ func TestRenderOperationMethodSingleItemMapsUseMultilineFormat(t *testing.T) {
 	}
 }
 
-func TestRenderOperationMethodPaginationQueryBuilderAndTokenInitOverrides(t *testing.T) {
+func TestRenderOperationMethodPaginationQueryBuilderUsesDefaultTokenInit(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{
 		Path:   "/v1/workflows/{workflow_id}/versions",
@@ -1212,13 +1212,12 @@ func TestRenderOperationMethodPaginationQueryBuilderAndTokenInitOverrides(t *tes
 		},
 	}
 	mapping := &config.OperationMapping{
-		QueryBuilder:                "dump_exclude_none",
-		Pagination:                  "token",
-		PaginationDataClass:         "_PrivateListWorkflowVersionData",
-		PaginationItemType:          "WorkflowVersionInfo",
-		PaginationPageTokenField:    "page_token",
-		PaginationPageSizeField:     "page_size",
-		PaginationInitPageTokenExpr: "page_token or \"\"",
+		QueryBuilder:             "dump_exclude_none",
+		Pagination:               "token",
+		PaginationDataClass:      "_PrivateListWorkflowVersionData",
+		PaginationItemType:       "WorkflowVersionInfo",
+		PaginationPageTokenField: "page_token",
+		PaginationPageSizeField:  "page_size",
 	}
 
 	syncCode := pygen.RenderOperationMethod(doc, pygen.OperationBinding{
@@ -1236,8 +1235,8 @@ func TestRenderOperationMethodPaginationQueryBuilderAndTokenInitOverrides(t *tes
 	if strings.Contains(syncCode, "params = dump_exclude_none(") {
 		t.Fatalf("expected sync token pagination params to be inlined:\n%s", syncCode)
 	}
-	if !strings.Contains(syncCode, "page_token=page_token or \"\"") {
-		t.Fatalf("expected custom pagination token init expr in sync code:\n%s", syncCode)
+	if !strings.Contains(syncCode, "page_token=page_token or \"\",") {
+		t.Fatalf("expected default pagination token init expr in sync code:\n%s", syncCode)
 	}
 
 	asyncCode := pygen.RenderOperationMethod(doc, pygen.OperationBinding{
@@ -1255,8 +1254,8 @@ func TestRenderOperationMethodPaginationQueryBuilderAndTokenInitOverrides(t *tes
 	if strings.Contains(asyncCode, "params = dump_exclude_none(") {
 		t.Fatalf("expected async token pagination params to be inlined:\n%s", asyncCode)
 	}
-	if !strings.Contains(asyncCode, "page_token=page_token or \"\"") {
-		t.Fatalf("expected custom pagination token init expr in async code:\n%s", asyncCode)
+	if !strings.Contains(asyncCode, "page_token=page_token or \"\",") {
+		t.Fatalf("expected default pagination token init expr in async code:\n%s", asyncCode)
 	}
 }
 

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -901,13 +901,13 @@ func renderOperationMethodWithContext(
 		for _, field := range queryFields {
 			if field.RawName == pageTokenField {
 				tokenExpr = field.ArgName
+				if !field.Required {
+					tokenExpr = fmt.Sprintf("%s or \"\"", field.ArgName)
+				}
 			}
 			if field.RawName == pageSizeField {
 				sizeExpr = field.ArgName
 			}
-		}
-		if tokenInitExpr := strings.TrimSpace(binding.Mapping.PaginationInitPageTokenExpr); tokenInitExpr != "" {
-			tokenExpr = tokenInitExpr
 		}
 		EnsureTrailingNewlines(&buf, 2)
 		if async {


### PR DESCRIPTION
## Summary
- Remove `api.operation_mappings[].pagination_init_page_token_expr` from the generator config schema and `config/generator.yaml`.
- Remove the dedicated pagination token init override branch in Python operation rendering.
- Define default behavior as:
  - For token pagination, if the page token field is optional, initialize with `page_token or ""`.
  - Otherwise use the field value as-is.
- Update generator test coverage to validate default token-init behavior without config override.

## Non-overlap With Existing Open PRs
- This PR does not overlap with current open config-removal tracks:
  - `body_call_expr`
  - `response_unwrap_list_first`
  - `force_multiline_signature`

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.2%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh` (zero diff)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-oQNWoq --ci-check`

## Downstream PR
- coze-py PR: https://github.com/coze-dev/coze-py/pull/406
