### PR TITLE
refactor(codegen): remove stream_wrap_sync_response_var config

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -5272,7 +5272,6 @@ api:
         - event
         - data
       stream_wrap_async_yield: true
-      stream_wrap_sync_response_var: resp
       stream_wrap_compact_sync_return: true
       force_multiline_request_call: true
       response_type: Stream[WorkflowEvent]
@@ -5307,7 +5306,6 @@ api:
         - event
         - data
       stream_wrap_async_yield: true
-      stream_wrap_sync_response_var: resp
       stream_wrap_compact_sync_return: true
       force_multiline_request_call: true
       response_type: Stream[WorkflowEvent]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,7 +197,6 @@ type OperationMapping struct {
 	StreamWrapHandler              string            `yaml:"stream_wrap_handler"`
 	StreamWrapFields               []string          `yaml:"stream_wrap_fields"`
 	StreamWrapAsyncYield           bool              `yaml:"stream_wrap_async_yield"`
-	StreamWrapSyncResponseVar      string            `yaml:"stream_wrap_sync_response_var"`
 	StreamWrapCompactAsyncReturn   bool              `yaml:"stream_wrap_compact_async_return"`
 	StreamWrapCompactSyncReturn    bool              `yaml:"stream_wrap_compact_sync_return"`
 	QueryBuilder                   string            `yaml:"query_builder"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -512,7 +512,7 @@ func TestRenderOperationMethodStreamWrap(t *testing.T) {
 	}
 }
 
-func TestRenderOperationMethodStreamWrapYieldAndSyncVarOverride(t *testing.T) {
+func TestRenderOperationMethodStreamWrapYieldAndSyncVarDefault(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{
 		Path:   "/v1/demo/stream",
@@ -531,17 +531,16 @@ func TestRenderOperationMethodStreamWrapYieldAndSyncVarOverride(t *testing.T) {
 			StreamWrapHandler:         "handle_demo",
 			StreamWrapFields:          []string{"event", "data"},
 			StreamWrapAsyncYield:      true,
-			StreamWrapSyncResponseVar: "resp",
 			ForceMultilineRequestCall: false,
 		},
 	}
 
 	syncCode := pygen.RenderOperationMethod(doc, binding, false)
-	if !strings.Contains(syncCode, "resp: IteratorHTTPResponse[str] = self._requester.request(") {
-		t.Fatalf("expected sync stream response var override:\n%s", syncCode)
+	if !strings.Contains(syncCode, "response: IteratorHTTPResponse[str] = self._requester.request(") {
+		t.Fatalf("expected sync stream response var to use default name:\n%s", syncCode)
 	}
-	if !strings.Contains(syncCode, "resp._raw_response") || !strings.Contains(syncCode, "resp.data") {
-		t.Fatalf("expected sync stream var to be reused in return:\n%s", syncCode)
+	if !strings.Contains(syncCode, "response._raw_response") || !strings.Contains(syncCode, "response.data") {
+		t.Fatalf("expected default sync stream var to be reused in return:\n%s", syncCode)
 	}
 
 	asyncCode := pygen.RenderOperationMethod(doc, binding, true)

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -478,6 +478,7 @@ func renderOperationMethodWithContext(
 	streamWrapHandler := ""
 	streamWrapFields := []string{}
 	streamWrapAsyncYield := false
+	// Keep a stable sync stream response variable name after removing mapping override.
 	streamWrapSyncResponseVar := "response"
 	streamWrapCompactAsyncReturn := false
 	streamWrapCompactSyncReturn := false
@@ -543,9 +544,6 @@ func renderOperationMethodWithContext(
 			streamWrapFields = append(streamWrapFields, binding.Mapping.StreamWrapFields...)
 		}
 		streamWrapAsyncYield = binding.Mapping.StreamWrapAsyncYield
-		if varName := strings.TrimSpace(binding.Mapping.StreamWrapSyncResponseVar); varName != "" {
-			streamWrapSyncResponseVar = varName
-		}
 		streamWrapCompactAsyncReturn = binding.Mapping.StreamWrapCompactAsyncReturn
 		streamWrapCompactSyncReturn = binding.Mapping.StreamWrapCompactSyncReturn
 		headersExpr = strings.TrimSpace(binding.Mapping.HeadersExpr)


### PR DESCRIPTION
## Summary
- remove `stream_wrap_sync_response_var` from `OperationMapping` config schema
- remove Python renderer support for overriding sync stream response variable name
- remove all `stream_wrap_sync_response_var` entries from `config/generator.yaml`
- keep a stable default sync stream response variable name: `response`

## Scope Control / Non-duplication
Reviewed recent/open PRs and avoided config items already merged or in-flight (e.g. `disable_request_body`, `response_unwrap_list_first`, `force_multiline_signature`).
This PR only targets `stream_wrap_sync_response_var`.

## Behavior
For sync stream-wrap methods, generated code now always uses `response` as the typed response variable.
This is a readability/style alignment change; request behavior is unchanged.

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (coverage 83.2%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh` (zero diff)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-dLzl23 --ci-check`
  - poetry build / ruff / mypy passed
  - pytest passed: 285 passed

## Traceability

- downstream coze-py PR: https://github.com/coze-dev/coze-py/pull/407
