### PR TITLE
refactor(py): remove no_blank_line_after_headers config

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4591,7 +4591,6 @@ api:
       order: 74
       sdk_methods:
         - folders.retrieve
-      no_blank_line_after_headers: true
       http_method_override: GET
       response_type: SimpleFolder
       response_cast: SimpleFolder
@@ -5431,7 +5430,6 @@ api:
       stream_wrap_fields:
         - event
         - data
-      no_blank_line_after_headers: true
       force_multiline_request_call: true
       stream_wrap_compact_async_return: true
       response_type: Stream[ChatEvent]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,7 +203,6 @@ type OperationMapping struct {
 	QueryBuilder                   string            `yaml:"query_builder"`
 	BodyFieldValues                map[string]string `yaml:"body_field_values"`
 	HeadersExpr                    string            `yaml:"headers_expr"`
-	NoBlankLineAfterHeaders        bool              `yaml:"no_blank_line_after_headers"`
 	ForceMultilineSignatureSync    bool              `yaml:"force_multiline_signature_sync"`
 	ForceMultilineRequestCall      bool              `yaml:"force_multiline_request_call"`
 	ForceMultilineRequestCallAsync bool              `yaml:"force_multiline_request_call_async"`

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -1271,9 +1271,6 @@ func renderOperationMethodWithContext(
 			requestBodyType != "" ||
 			strings.EqualFold(requestMethod, "delete") ||
 			(binding.Mapping != nil && len(binding.Mapping.PreBodyCode) > 0)
-		if binding.Mapping != nil && binding.Mapping.NoBlankLineAfterHeaders {
-			needsBlankLine = false
-		}
 		if needsBlankLine {
 			buf.WriteString("        headers: Optional[dict] = kwargs.get(\"headers\")\n\n")
 		} else {


### PR DESCRIPTION
## Summary
- remove `no_blank_line_after_headers` compatibility config from `generator.yaml`
- remove corresponding `OperationMapping` field and Python renderer branch
- default behavior is now unified: header-spacing relies on the built-in blank-line heuristic only

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (total coverage: `83.2%`)
- `./scripts/build.sh`
- `./scripts/gengo.sh --output-sdk exist-repo/coze-go-generated`
- `./scripts/diffgo.sh` (no diff output)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-LRL6kZ --ci-check` (no pysdk diff)

## Traceability
- downstream `coze-py` PR: https://github.com/coze-dev/coze-py/pull/408
