### PR TITLE
refactor(codegen): remove body_annotation config support

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -3918,7 +3918,6 @@ api:
         - bot_id
         - name
         - connector_id
-      body_annotation: Dict[str, Any]
       arg_types:
         messages: List[Message]
         meta_data: Dict[str, str]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -164,7 +164,6 @@ type OperationMapping struct {
 	FilesFieldValues               map[string]string `yaml:"files_field_values"`
 	FilesExpr                      string            `yaml:"files_expr"`
 	FilesBeforeBody                bool              `yaml:"files_before_body"`
-	BodyAnnotation                 string            `yaml:"body_annotation"`
 	PreDocstringCode               []string          `yaml:"pre_docstring_code"`
 	PreBodyCode                    []string          `yaml:"pre_body_code"`
 	BodyRequiredFields             []string          `yaml:"body_required_fields"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1093,8 +1093,7 @@ func TestRenderOperationMethodPreBodyCode(t *testing.T) {
 		MethodName:  "publish",
 		Details:     details,
 		Mapping: &config.OperationMapping{
-			BodyFields:     []string{"bot_id", "connector_ids"},
-			BodyAnnotation: "Dict[str, Any]",
+			BodyFields: []string{"bot_id", "connector_ids"},
 			ArgTypes: map[string]string{
 				"bot_id":        "str",
 				"connector_ids": "List[str]",
@@ -1107,11 +1106,11 @@ func TestRenderOperationMethodPreBodyCode(t *testing.T) {
 	if !strings.Contains(code, "if not connector_ids:") || !strings.Contains(code, "connector_ids = [\"1024\"]") {
 		t.Fatalf("expected pre body code block in method:\n%s", code)
 	}
-	if strings.Index(code, "if not connector_ids:") > strings.Index(code, "body: Dict[str, Any] =") {
+	if strings.Index(code, "if not connector_ids:") > strings.Index(code, "body =") {
 		t.Fatalf("expected pre body code to appear before body assignment:\n%s", code)
 	}
-	if !strings.Contains(code, "body: Dict[str, Any] =") {
-		t.Fatalf("expected body annotation in assignment:\n%s", code)
+	if strings.Contains(code, "body:") {
+		t.Fatalf("expected body assignment without explicit annotation:\n%s", code)
 	}
 }
 

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -563,13 +563,11 @@ func renderOperationMethodWithContext(
 	requestStream := false
 	queryBuilder := "dump_exclude_none"
 	bodyBuilder := "dump_exclude_none"
-	bodyAnnotation := ""
 	if binding.Mapping != nil {
 		dataField = strings.TrimSpace(binding.Mapping.DataField)
 		requestStream = binding.Mapping.RequestStream
 		queryBuilder = normalizeMapBuilder(binding.Mapping.QueryBuilder)
 		bodyBuilder = normalizeMapBuilder(binding.Mapping.BodyBuilder)
-		bodyAnnotation = strings.TrimSpace(binding.Mapping.BodyAnnotation)
 	}
 	autoDelegateTo := autoDelegateTarget(binding.MethodName, classMethodNames)
 	autoDelegateExtraArgs := make([]string, 0, 1)
@@ -1137,9 +1135,6 @@ func renderOperationMethodWithContext(
 		}
 	}
 	bodyVarAssign := "body"
-	if bodyAnnotation != "" {
-		bodyVarAssign = fmt.Sprintf("body: %s", bodyAnnotation)
-	}
 	renderFilesAssignment := func() bool {
 		if filesExpr != "" {
 			buf.WriteString(fmt.Sprintf("        files = %s\n", filesExpr))


### PR DESCRIPTION
## Summary
- Remove `api.operation_mappings[].body_annotation` from generator config schema and `config/generator.yaml`.
- Remove Python operation rendering support for mapping-level body variable annotations.
- Define default behavior as always generating body assignment without an explicit local type annotation (`body = ...`).
- Update generator tests to assert pre-body code order and unannotated body assignment.

## Non-overlap With Existing Open PRs
- This PR does not overlap with current open config-removal tracks:
  - `disable_request_body`
  - `response_unwrap_list_first`

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.2%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh` (zero diff)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-V4wch2 --ci-check`

## Downstream PR
- coze-py PR: https://github.com/coze-dev/coze-py/pull/409
