### PR TITLE
feat(codegen): remove stream_wrap_compact_async_return option

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -5428,7 +5428,6 @@ api:
         - event
         - data
       force_multiline_request_call: true
-      stream_wrap_compact_async_return: true
       response_type: Stream[ChatEvent]
       async_response_type: AsyncIterator[ChatEvent]
       response_cast: None

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,7 +197,6 @@ type OperationMapping struct {
 	StreamWrapHandler              string            `yaml:"stream_wrap_handler"`
 	StreamWrapFields               []string          `yaml:"stream_wrap_fields"`
 	StreamWrapAsyncYield           bool              `yaml:"stream_wrap_async_yield"`
-	StreamWrapCompactAsyncReturn   bool              `yaml:"stream_wrap_compact_async_return"`
 	StreamWrapCompactSyncReturn    bool              `yaml:"stream_wrap_compact_sync_return"`
 	QueryBuilder                   string            `yaml:"query_builder"`
 	BodyFieldValues                map[string]string `yaml:"body_field_values"`

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -480,7 +480,6 @@ func renderOperationMethodWithContext(
 	streamWrapAsyncYield := false
 	// Keep a stable sync stream response variable name after removing mapping override.
 	streamWrapSyncResponseVar := "response"
-	streamWrapCompactAsyncReturn := false
 	streamWrapCompactSyncReturn := false
 	bodyFieldValues := map[string]string{}
 	paramAliases := map[string]string{}
@@ -544,7 +543,6 @@ func renderOperationMethodWithContext(
 			streamWrapFields = append(streamWrapFields, binding.Mapping.StreamWrapFields...)
 		}
 		streamWrapAsyncYield = binding.Mapping.StreamWrapAsyncYield
-		streamWrapCompactAsyncReturn = binding.Mapping.StreamWrapCompactAsyncReturn
 		streamWrapCompactSyncReturn = binding.Mapping.StreamWrapCompactSyncReturn
 		headersExpr = strings.TrimSpace(binding.Mapping.HeadersExpr)
 		if override := strings.TrimSpace(binding.Mapping.PaginationRequestArg); override != "" {
@@ -1368,28 +1366,16 @@ func renderOperationMethodWithContext(
 				buf.WriteString("        ):\n")
 				buf.WriteString("            yield item\n")
 			} else {
-				if streamWrapCompactAsyncReturn {
-					asyncStreamArgs := []string{"resp.data"}
-					if len(fieldLiterals) > 0 {
-						asyncStreamArgs = append(asyncStreamArgs, fmt.Sprintf("fields=[%s]", strings.Join(fieldLiterals, ", ")))
-					}
-					if streamWrapHandler != "" {
-						asyncStreamArgs = append(asyncStreamArgs, fmt.Sprintf("handler=%s", streamWrapHandler))
-					}
-					asyncStreamArgs = append(asyncStreamArgs, "raw_response=resp._raw_response")
-					buf.WriteString(fmt.Sprintf("        return AsyncStream(%s)\n", strings.Join(asyncStreamArgs, ", ")))
-				} else {
-					buf.WriteString("        return AsyncStream(\n")
-					buf.WriteString("            resp.data,\n")
-					if len(fieldLiterals) > 0 {
-						buf.WriteString(fmt.Sprintf("            fields=[%s],\n", strings.Join(fieldLiterals, ", ")))
-					}
-					if streamWrapHandler != "" {
-						buf.WriteString(fmt.Sprintf("            handler=%s,\n", streamWrapHandler))
-					}
-					buf.WriteString("            raw_response=resp._raw_response,\n")
-					buf.WriteString("        )\n")
+				buf.WriteString("        return AsyncStream(\n")
+				buf.WriteString("            resp.data,\n")
+				if len(fieldLiterals) > 0 {
+					buf.WriteString(fmt.Sprintf("            fields=[%s],\n", strings.Join(fieldLiterals, ", ")))
 				}
+				if streamWrapHandler != "" {
+					buf.WriteString(fmt.Sprintf("            handler=%s,\n", streamWrapHandler))
+				}
+				buf.WriteString("            raw_response=resp._raw_response,\n")
+				buf.WriteString("        )\n")
 			}
 		} else {
 			if forceMultilineRequestCall {


### PR DESCRIPTION
## Summary
- remove `stream_wrap_compact_async_return` from `generator.yaml` and `OperationMapping`
- simplify async stream-wrap generation to always use the standard multiline `AsyncStream(...)` return
- keep `stream_wrap_compact_sync_return` behavior unchanged and update generator tests accordingly

## Validation
- ./scripts/fmt.sh
- ./scripts/lint.sh
- ./scripts/test.sh
- ./scripts/build.sh
- ./scripts/gengo.sh
- ./scripts/diffgo.sh
- ./scripts/genpy.sh --output-sdk /tmp/coze-py-zJLIn8 --ci-check

## Downstream
- coze-py PR: https://github.com/coze-dev/coze-py/pull/410
