### PR TITLE
refactor(py): remove force_multiline_request_call config

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -3800,7 +3800,6 @@ api:
       order: 20
       sdk_methods:
         - api_apps.update
-      force_multiline_request_call: true
       body_fields:
         - name
         - callback_url
@@ -3969,7 +3968,6 @@ api:
       order: 61
       sdk_methods:
         - datasets.create
-      force_multiline_request_call: true
       body_builder: raw
       allow_missing_in_swagger: true
       body_fields:
@@ -4027,7 +4025,6 @@ api:
       order: 63
       sdk_methods:
         - datasets.update
-      force_multiline_request_call: true
       body_builder: raw
       body_fields:
         - name
@@ -4041,7 +4038,6 @@ api:
       order: 64
       sdk_methods:
         - datasets.delete
-      force_multiline_request_call: true
       allow_missing_in_swagger: true
       response_type: DeleteDatasetRes
     - path: /v1/datasets/{dataset_id}/process
@@ -4049,7 +4045,6 @@ api:
       order: 65
       sdk_methods:
         - datasets.process
-      force_multiline_request_call: true
       body_builder: raw
       body_fields:
         - document_ids
@@ -4152,7 +4147,6 @@ api:
         document_id: str
         document_name: str
         update_rule: Optional[DocumentUpdateRule]
-      force_multiline_request_call: true
       response_type: UpdateDocumentRes
     - path: /open_api/knowledge/document/delete
       method: post
@@ -4166,7 +4160,6 @@ api:
         - document_ids
       arg_types:
         document_ids: List[str]
-      force_multiline_request_call: true
       response_type: DeleteDocumentRes
     - path: /open_api/knowledge/document/list
       method: post
@@ -4261,7 +4254,6 @@ api:
               DeprecationWarning,
               stacklevel=2,
           )
-      force_multiline_request_call: true
       response_type: None
     - path: /open_api/knowledge/document/delete
       method: post
@@ -4283,7 +4275,6 @@ api:
               DeprecationWarning,
               stacklevel=2,
           )
-      force_multiline_request_call: true
       response_type: None
     - path: /open_api/knowledge/document/list
       method: post
@@ -5197,7 +5188,6 @@ api:
         - data
       stream_wrap_async_yield: true
       stream_wrap_compact_sync_return: true
-      force_multiline_request_call: true
       response_type: Stream[WorkflowEvent]
       async_response_type: AsyncIterator[WorkflowEvent]
       response_cast: None
@@ -5231,7 +5221,6 @@ api:
         - data
       stream_wrap_async_yield: true
       stream_wrap_compact_sync_return: true
-      force_multiline_request_call: true
       response_type: Stream[WorkflowEvent]
       async_response_type: AsyncIterator[WorkflowEvent]
       response_cast: None
@@ -5349,7 +5338,6 @@ api:
       stream_wrap_fields:
         - event
         - data
-      force_multiline_request_call: true
       response_type: Stream[ChatEvent]
       async_response_type: AsyncIterator[ChatEvent]
       response_cast: None

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -200,7 +200,6 @@ type OperationMapping struct {
 	BodyFieldValues                map[string]string `yaml:"body_field_values"`
 	HeadersExpr                    string            `yaml:"headers_expr"`
 	ForceMultilineSignatureSync    bool              `yaml:"force_multiline_signature_sync"`
-	ForceMultilineRequestCall      bool              `yaml:"force_multiline_request_call"`
 	ForceMultilineRequestCallAsync bool              `yaml:"force_multiline_request_call_async"`
 	PaginationRequestArg           string            `yaml:"pagination_request_arg"`
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -523,15 +523,14 @@ func TestRenderOperationMethodStreamWrapYieldAndSyncVarDefault(t *testing.T) {
 		MethodName:  "stream_call",
 		Details:     details,
 		Mapping: &config.OperationMapping{
-			RequestStream:             true,
-			ResponseType:              "Stream[DemoEvent]",
-			AsyncResponseType:         "AsyncIterator[DemoEvent]",
-			ResponseCast:              "None",
-			StreamWrap:                true,
-			StreamWrapHandler:         "handle_demo",
-			StreamWrapFields:          []string{"event", "data"},
-			StreamWrapAsyncYield:      true,
-			ForceMultilineRequestCall: false,
+			RequestStream:        true,
+			ResponseType:         "Stream[DemoEvent]",
+			AsyncResponseType:    "AsyncIterator[DemoEvent]",
+			ResponseCast:         "None",
+			StreamWrap:           true,
+			StreamWrapHandler:    "handle_demo",
+			StreamWrapFields:     []string{"event", "data"},
+			StreamWrapAsyncYield: true,
 		},
 	}
 

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -1314,12 +1314,7 @@ func renderOperationMethodWithContext(
 		callArgs = append(callArgs, item.Expr)
 	}
 	requestExpr := fmt.Sprintf("%s(%s)", requestCall, strings.Join(callArgs, ", "))
-	forceMultilineRequestCall := false
-	if binding.Mapping != nil {
-		if async && binding.Mapping.ForceMultilineRequestCallAsync {
-			forceMultilineRequestCall = true
-		}
-	}
+	forceMultilineRequestCall := async && binding.Mapping != nil && binding.Mapping.ForceMultilineRequestCallAsync
 	if binding.Mapping != nil && binding.Mapping.ResponseUnwrapListFirst {
 		buf.WriteString(fmt.Sprintf("        res = %s\n", requestExpr))
 		buf.WriteString("        data = res.data[0]\n")

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -1314,7 +1314,7 @@ func renderOperationMethodWithContext(
 		callArgs = append(callArgs, item.Expr)
 	}
 	requestExpr := fmt.Sprintf("%s(%s)", requestCall, strings.Join(callArgs, ", "))
-	forceMultilineRequestCall := binding.Mapping != nil && binding.Mapping.ForceMultilineRequestCall
+	forceMultilineRequestCall := false
 	if binding.Mapping != nil {
 		if async && binding.Mapping.ForceMultilineRequestCallAsync {
 			forceMultilineRequestCall = true


### PR DESCRIPTION
## Summary
- remove `force_multiline_request_call` compatibility config from `generator.yaml`
- remove corresponding `OperationMapping` field and Python renderer branch
- default behavior: request call formatting is no longer forced multiline; it follows the generator's normal output style
- keep `force_multiline_request_call_async` support unchanged

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (total coverage: `83.1%`)
- `./scripts/build.sh`
- `./scripts/gengo.sh --output-sdk exist-repo/coze-go-generated`
- `./scripts/diffgo.sh` (no diff output)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-EGuJh4 --ci-check`

## Traceability
- downstream `coze-py` PR: https://github.com/coze-dev/coze-py/pull/411
