### PR TITLE
refactor(py): remove response_cast config and infer cast automatically

### DIFF
--- a/cmd/coze-sdk-gen/main_test.go
+++ b/cmd/coze-sdk-gen/main_test.go
@@ -93,7 +93,6 @@ api:
       arg_types:
         name: str
       response_type: DemoResp
-      response_cast: DemoResp
 `)
 
 	var out bytes.Buffer

--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -3680,7 +3680,6 @@ api:
         - data
       response_type: Stream[ChatEvent]
       async_response_type: AsyncIterator[ChatEvent]
-      response_cast: None
     - path: /v3/chat/retrieve
       method: get
       order: 3
@@ -4225,7 +4224,6 @@ api:
               stacklevel=2,
           )
       response_type: List[Document]
-      response_cast: "[Document]"
       data_field: document_infos
     - path: /open_api/knowledge/document/update
       method: post
@@ -5190,7 +5188,6 @@ api:
       stream_wrap_compact_sync_return: true
       response_type: Stream[WorkflowEvent]
       async_response_type: AsyncIterator[WorkflowEvent]
-      response_cast: None
     - path: /v1/workflow/stream_resume
       method: post
       order: 92
@@ -5223,14 +5220,12 @@ api:
       stream_wrap_compact_sync_return: true
       response_type: Stream[WorkflowEvent]
       async_response_type: AsyncIterator[WorkflowEvent]
-      response_cast: None
     - path: /v1/workflows/{workflow_id}/run_histories/{execute_id}
       method: get
       order: 93
       sdk_methods:
         - workflows_runs_run_histories.retrieve
       response_type: WorkflowRunHistory
-      response_cast: ListResponse[WorkflowRunHistory]
       response_unwrap_list_first: true
     - path: /v1/workflows/{workflow_id}/run_histories/{execute_id}/execute_nodes/{node_execute_uuid}
       method: get
@@ -5304,7 +5299,6 @@ api:
         - data
       response_type: Stream[ChatEvent]
       async_response_type: AsyncIterator[ChatEvent]
-      response_cast: None
     - path: /v1/workflows/chat
       method: post
       order: 97
@@ -5340,7 +5334,6 @@ api:
         - data
       response_type: Stream[ChatEvent]
       async_response_type: AsyncIterator[ChatEvent]
-      response_cast: None
     - path: /v1/workspaces
       method: get
       order: 969

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -170,7 +170,6 @@ type OperationMapping struct {
 	ArgTypes                       map[string]string `yaml:"arg_types"`
 	ResponseType                   string            `yaml:"response_type"`
 	AsyncResponseType              string            `yaml:"async_response_type"`
-	ResponseCast                   string            `yaml:"response_cast"`
 	QueryFields                    []OperationField  `yaml:"query_fields"`
 	QueryFieldValues               map[string]string `yaml:"query_field_values"`
 	ArgDefaults                    map[string]string `yaml:"arg_defaults"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -488,7 +488,6 @@ func TestRenderOperationMethodStreamWrap(t *testing.T) {
 			RequestStream:     true,
 			ResponseType:      "Stream[DemoEvent]",
 			AsyncResponseType: "AsyncStream[DemoEvent]",
-			ResponseCast:      "None",
 			StreamWrap:        true,
 			StreamWrapHandler: "handle_demo",
 			StreamWrapFields:  []string{"event", "data"},
@@ -526,7 +525,6 @@ func TestRenderOperationMethodStreamWrapYieldAndSyncVarDefault(t *testing.T) {
 			RequestStream:        true,
 			ResponseType:         "Stream[DemoEvent]",
 			AsyncResponseType:    "AsyncIterator[DemoEvent]",
-			ResponseCast:         "None",
 			StreamWrap:           true,
 			StreamWrapHandler:    "handle_demo",
 			StreamWrapFields:     []string{"event", "data"},
@@ -565,7 +563,6 @@ func TestRenderOperationMethodStreamWrapCompactSyncReturn(t *testing.T) {
 			RequestStream:               true,
 			ResponseType:                "Stream[DemoEvent]",
 			AsyncResponseType:           "AsyncIterator[DemoEvent]",
-			ResponseCast:                "None",
 			StreamWrap:                  true,
 			StreamWrapHandler:           "handle_demo",
 			StreamWrapFields:            []string{"event", "data"},
@@ -892,7 +889,6 @@ func TestRenderOperationMethodKwargsOnlySignatureForEmptyBodySchema(t *testing.T
 		Details:     details,
 		Mapping: &config.OperationMapping{
 			ResponseType: "User",
-			ResponseCast: "User",
 		},
 	}, false)
 	if !strings.Contains(code, "def me(self, **kwargs)") {
@@ -1016,7 +1012,6 @@ func TestRenderOperationMethodAsyncStreamMethodDefaultsToYield(t *testing.T) {
 		},
 		ResponseType:      "Stream[ChatEvent]",
 		AsyncResponseType: "AsyncIterator[ChatEvent]",
-		ResponseCast:      "None",
 		BodyBuilder:       "remove_none_values",
 		BodyFields:        []string{"workflow_id"},
 		BodyRequiredFields: []string{
@@ -1275,7 +1270,6 @@ func TestRenderOperationMethodResponseUnwrapListFirst(t *testing.T) {
 		Details:     details,
 		Mapping: &config.OperationMapping{
 			ResponseType:            "WorkflowRunHistory",
-			ResponseCast:            "ListResponse[WorkflowRunHistory]",
 			ResponseUnwrapListFirst: true,
 		},
 	}, false)
@@ -1292,7 +1286,6 @@ func TestRenderOperationMethodResponseUnwrapListFirst(t *testing.T) {
 		Details:     details,
 		Mapping: &config.OperationMapping{
 			ResponseType:            "WorkflowRunHistory",
-			ResponseCast:            "ListResponse[WorkflowRunHistory]",
 			ResponseUnwrapListFirst: true,
 		},
 	}, true)

--- a/internal/generator/python/generator.go
+++ b/internal/generator/python/generator.go
@@ -1338,12 +1338,14 @@ func packageNeedsListResponseImport(bindings []OperationBinding) bool {
 		candidates := []string{
 			binding.Mapping.ResponseType,
 			binding.Mapping.AsyncResponseType,
-			binding.Mapping.ResponseCast,
 		}
 		for _, candidate := range candidates {
 			if strings.Contains(strings.TrimSpace(candidate), "ListResponse[") {
 				return true
 			}
+		}
+		if binding.Mapping.ResponseUnwrapListFirst {
+			return true
 		}
 	}
 	return false

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -523,14 +523,8 @@ func renderOperationMethodWithContext(
 				returnType = mappedAsyncReturnType
 			}
 		}
-		if mappedReturnCast := strings.TrimSpace(binding.Mapping.ResponseCast); mappedReturnCast != "" {
-			returnCast = mappedReturnCast
-		} else if strings.TrimSpace(binding.Mapping.ResponseType) != "" {
-			returnCast = strings.TrimSpace(binding.Mapping.ResponseType)
-		}
 		shouldInferResponseModel := strings.TrimSpace(binding.Mapping.ResponseType) == "" &&
 			strings.TrimSpace(binding.Mapping.AsyncResponseType) == "" &&
-			strings.TrimSpace(binding.Mapping.ResponseCast) == "" &&
 			(strings.TrimSpace(returnType) == "" || strings.TrimSpace(returnType) == "Dict[str, Any]")
 		if shouldInferResponseModel {
 			if inferredModelName, ok := inferBindingResponseModelName(doc, &config.Package{Name: binding.PackageName}, binding); ok {
@@ -554,6 +548,7 @@ func renderOperationMethodWithContext(
 			}
 		}
 	}
+	returnCast = inferResponseCast(binding.Mapping, returnType, returnCast)
 	if ignoreHeaderParams {
 		details.HeaderParameters = nil
 	}


### PR DESCRIPTION
## Summary
- remove all `response_cast` entries from `config/generator.yaml`
- remove `ResponseCast` from `OperationMapping`
- infer request `cast` automatically in Python generator:
  - stream return types -> `cast=None`
  - `response_unwrap_list_first: true` -> `cast=ListResponse[<response_type>]`
  - `response_type: List[T]` -> `cast=[T]`
  - otherwise fallback to `response_type`
- add unit tests for cast inference and update existing generator tests

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (coverage: 83.2%)
- `./scripts/build.sh`
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-oQNWoq --ci-check`
- `git -C /tmp/coze-py-oQNWoq status -sb` (no diff, PySDK 0 diff)

## Downstream
- no `coze-py` PR is needed because generated output is 0 diff against `origin/main`.
