### PR TITLE
refactor(codegen): remove async_include_kwargs config support

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4419,7 +4419,6 @@ api:
       sdk_methods:
         - bots._list_v1
       query_builder: raw
-      async_include_kwargs: true
       query_fields:
         - name: space_id
           type: str

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,7 +186,6 @@ type OperationMapping struct {
 	PaginationPageNumField         string            `yaml:"pagination_page_num_field"`
 	PaginationPageSizeField        string            `yaml:"pagination_page_size_field"`
 	PaginationPageTokenField       string            `yaml:"pagination_page_token_field"`
-	AsyncIncludeKwargs             bool              `yaml:"async_include_kwargs"`
 	IgnoreHeaderParams             bool              `yaml:"ignore_header_params"`
 	DataField                      string            `yaml:"data_field"`
 	ResponseUnwrapListFirst        bool              `yaml:"response_unwrap_list_first"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -847,7 +847,7 @@ func TestGeneratePythonMappingGeneratesSyncAndAsyncByDefault(t *testing.T) {
 	}
 }
 
-func TestRenderOperationMethodReturnAndAsyncKwargsOptions(t *testing.T) {
+func TestRenderOperationMethodReturnAndAsyncKwargs(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{
 		Path:   "/v1/demo",
@@ -868,12 +868,10 @@ func TestRenderOperationMethodReturnAndAsyncKwargsOptions(t *testing.T) {
 		PackageName: "demo",
 		MethodName:  "async_call",
 		Details:     details,
-		Mapping: &config.OperationMapping{
-			AsyncIncludeKwargs: true,
-		},
+		Mapping:     &config.OperationMapping{},
 	}, true)
 	if !strings.Contains(asyncCode, "**kwargs") {
-		t.Fatalf("expected async kwargs passthrough in signature:\n%s", asyncCode)
+		t.Fatalf("expected async kwargs in signature by default:\n%s", asyncCode)
 	}
 }
 

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -474,7 +474,6 @@ func renderOperationMethodWithContext(
 	requestBodyType, bodyRequired := RequestBodyTypeInfo(doc, details.RequestBodySchema, details.RequestBody)
 	ignoreHeaderParams := binding.Mapping != nil && binding.Mapping.IgnoreHeaderParams
 	streamWrap := binding.Mapping != nil && binding.Mapping.StreamWrap
-	asyncIncludeKwargs := async && binding.Mapping != nil && binding.Mapping.AsyncIncludeKwargs
 	streamWrapHandler := ""
 	streamWrapFields := []string{}
 	streamWrapAsyncYield := false
@@ -709,9 +708,6 @@ func renderOperationMethodWithContext(
 	}
 	includeKwargsHeaders := true
 	if includeKwargsHeaders {
-		signatureArgs = append(signatureArgs, "**kwargs")
-	}
-	if asyncIncludeKwargs && !includeKwargsHeaders {
 		signatureArgs = append(signatureArgs, "**kwargs")
 	}
 	signatureArgs = NormalizeSignatureArgs(signatureArgs)


### PR DESCRIPTION
## Summary
- Remove `api.operation_mappings[].async_include_kwargs` from generator config schema and `config/generator.yaml`.
- Remove Python operation rendering branch for mapping-level async kwargs opt-in.
- Define default behavior as standard kwargs handling without per-operation override.
- Update generator tests to assert async kwargs presence by default path.

## Non-overlap With Existing Open PRs
- This PR does not overlap with current open config-removal tracks:
  - `force_multiline_request_call`
  - `response_cast`
  - `response_unwrap_list_first`

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.2%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh` (zero diff)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-qEF1lO --ci-check`

## Downstream PR
- coze-py PR: https://github.com/coze-dev/coze-py/pull/412
