### PR TITLE
refactor(codegen): remove stream_wrap_compact_sync_return option

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -5196,7 +5196,6 @@ api:
         - event
         - data
       stream_wrap_async_yield: true
-      stream_wrap_compact_sync_return: true
       force_multiline_request_call: true
       response_type: Stream[WorkflowEvent]
       async_response_type: AsyncIterator[WorkflowEvent]
@@ -5230,7 +5229,6 @@ api:
         - event
         - data
       stream_wrap_async_yield: true
-      stream_wrap_compact_sync_return: true
       force_multiline_request_call: true
       response_type: Stream[WorkflowEvent]
       async_response_type: AsyncIterator[WorkflowEvent]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -195,7 +195,6 @@ type OperationMapping struct {
 	StreamWrapHandler              string            `yaml:"stream_wrap_handler"`
 	StreamWrapFields               []string          `yaml:"stream_wrap_fields"`
 	StreamWrapAsyncYield           bool              `yaml:"stream_wrap_async_yield"`
-	StreamWrapCompactSyncReturn    bool              `yaml:"stream_wrap_compact_sync_return"`
 	QueryBuilder                   string            `yaml:"query_builder"`
 	BodyFieldValues                map[string]string `yaml:"body_field_values"`
 	HeadersExpr                    string            `yaml:"headers_expr"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -552,7 +552,7 @@ func TestRenderOperationMethodStreamWrapYieldAndSyncVarDefault(t *testing.T) {
 	}
 }
 
-func TestRenderOperationMethodStreamWrapCompactSyncReturn(t *testing.T) {
+func TestRenderOperationMethodStreamWrapSyncReturnMultiline(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{
 		Path:   "/v1/demo/stream",
@@ -563,19 +563,21 @@ func TestRenderOperationMethodStreamWrapCompactSyncReturn(t *testing.T) {
 		MethodName:  "stream_call",
 		Details:     details,
 		Mapping: &config.OperationMapping{
-			RequestStream:               true,
-			ResponseType:                "Stream[DemoEvent]",
-			AsyncResponseType:           "AsyncIterator[DemoEvent]",
-			ResponseCast:                "None",
-			StreamWrap:                  true,
-			StreamWrapHandler:           "handle_demo",
-			StreamWrapFields:            []string{"event", "data"},
-			StreamWrapCompactSyncReturn: true,
+			RequestStream:     true,
+			ResponseType:      "Stream[DemoEvent]",
+			AsyncResponseType: "AsyncIterator[DemoEvent]",
+			ResponseCast:      "None",
+			StreamWrap:        true,
+			StreamWrapHandler: "handle_demo",
+			StreamWrapFields:  []string{"event", "data"},
 		},
 	}
 	syncCode := pygen.RenderOperationMethod(doc, binding, false)
-	if !strings.Contains(syncCode, "return Stream(response._raw_response, response.data, fields=[\"event\", \"data\"], handler=handle_demo)") {
-		t.Fatalf("expected compact sync stream return line:\n%s", syncCode)
+	if strings.Contains(syncCode, "return Stream(response._raw_response, response.data, fields=[\"event\", \"data\"], handler=handle_demo)") {
+		t.Fatalf("did not expect compact sync stream return line:\n%s", syncCode)
+	}
+	if !strings.Contains(syncCode, "return Stream(\n            response._raw_response,\n            response.data,\n") {
+		t.Fatalf("expected multiline sync stream return:\n%s", syncCode)
 	}
 
 	asyncCode := pygen.RenderOperationMethod(doc, binding, true)

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -480,7 +480,6 @@ func renderOperationMethodWithContext(
 	streamWrapAsyncYield := false
 	// Keep a stable sync stream response variable name after removing mapping override.
 	streamWrapSyncResponseVar := "response"
-	streamWrapCompactSyncReturn := false
 	bodyFieldValues := map[string]string{}
 	paramAliases := map[string]string{}
 	argTypes := map[string]string{}
@@ -543,7 +542,6 @@ func renderOperationMethodWithContext(
 			streamWrapFields = append(streamWrapFields, binding.Mapping.StreamWrapFields...)
 		}
 		streamWrapAsyncYield = binding.Mapping.StreamWrapAsyncYield
-		streamWrapCompactSyncReturn = binding.Mapping.StreamWrapCompactSyncReturn
 		headersExpr = strings.TrimSpace(binding.Mapping.HeadersExpr)
 		if override := strings.TrimSpace(binding.Mapping.PaginationRequestArg); override != "" {
 			paginationRequestArg = override
@@ -1380,30 +1378,16 @@ func renderOperationMethodWithContext(
 			} else {
 				buf.WriteString(fmt.Sprintf("        %s: IteratorHTTPResponse[str] = %s\n", streamWrapSyncResponseVar, requestExpr))
 			}
-			if streamWrapCompactSyncReturn {
-				streamArgs := []string{
-					fmt.Sprintf("%s._raw_response", streamWrapSyncResponseVar),
-					fmt.Sprintf("%s.data", streamWrapSyncResponseVar),
-				}
-				if len(fieldLiterals) > 0 {
-					streamArgs = append(streamArgs, fmt.Sprintf("fields=[%s]", strings.Join(fieldLiterals, ", ")))
-				}
-				if streamWrapHandler != "" {
-					streamArgs = append(streamArgs, fmt.Sprintf("handler=%s", streamWrapHandler))
-				}
-				buf.WriteString(fmt.Sprintf("        return Stream(%s)\n", strings.Join(streamArgs, ", ")))
-			} else {
-				buf.WriteString("        return Stream(\n")
-				buf.WriteString(fmt.Sprintf("            %s._raw_response,\n", streamWrapSyncResponseVar))
-				buf.WriteString(fmt.Sprintf("            %s.data,\n", streamWrapSyncResponseVar))
-				if len(fieldLiterals) > 0 {
-					buf.WriteString(fmt.Sprintf("            fields=[%s],\n", strings.Join(fieldLiterals, ", ")))
-				}
-				if streamWrapHandler != "" {
-					buf.WriteString(fmt.Sprintf("            handler=%s,\n", streamWrapHandler))
-				}
-				buf.WriteString("        )\n")
+			buf.WriteString("        return Stream(\n")
+			buf.WriteString(fmt.Sprintf("            %s._raw_response,\n", streamWrapSyncResponseVar))
+			buf.WriteString(fmt.Sprintf("            %s.data,\n", streamWrapSyncResponseVar))
+			if len(fieldLiterals) > 0 {
+				buf.WriteString(fmt.Sprintf("            fields=[%s],\n", strings.Join(fieldLiterals, ", ")))
 			}
+			if streamWrapHandler != "" {
+				buf.WriteString(fmt.Sprintf("            handler=%s,\n", streamWrapHandler))
+			}
+			buf.WriteString("        )\n")
 		}
 	} else {
 		if forceMultilineRequestCall {


### PR DESCRIPTION
## Summary
- remove `stream_wrap_compact_sync_return` from `generator.yaml` and `OperationMapping`
- simplify sync stream-wrap generation to always use the standard multiline `Stream(...)` return
- keep `stream_wrap_async_yield` behavior unchanged and update generator tests accordingly

## Validation
- ./scripts/fmt.sh
- ./scripts/lint.sh
- ./scripts/test.sh
- ./scripts/build.sh
- ./scripts/gengo.sh
- ./scripts/diffgo.sh
- ./scripts/genpy.sh --output-sdk /tmp/coze-py-hX0yeP --ci-check

## Downstream
- coze-py PR: https://github.com/coze-dev/coze-py/pull/413
