### PR TITLE
refactor(codegen): remove force_multiline_request_call config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -196,7 +196,6 @@ type OperationMapping struct {
 	QueryBuilder                   string            `yaml:"query_builder"`
 	BodyFieldValues                map[string]string `yaml:"body_field_values"`
 	HeadersExpr                    string            `yaml:"headers_expr"`
-	ForceMultilineRequestCallAsync bool              `yaml:"force_multiline_request_call_async"`
 	PaginationRequestArg           string            `yaml:"pagination_request_arg"`
 }
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -585,40 +585,6 @@ func TestRenderOperationMethodStreamWrapSyncReturnMultiline(t *testing.T) {
 	}
 }
 
-func TestRenderOperationMethodForceMultilineRequestCallAsyncOnly(t *testing.T) {
-	doc := mustParseSwagger(t)
-	details := openapi.OperationDetails{
-		Path:   "/v1/demo",
-		Method: "post",
-		RequestBodySchema: &openapi.Schema{
-			Type: "object",
-			Properties: map[string]*openapi.Schema{
-				"name": {Type: "string"},
-			},
-		},
-	}
-	binding := pygen.OperationBinding{
-		PackageName: "demo",
-		MethodName:  "create",
-		Details:     details,
-		Mapping: &config.OperationMapping{
-			BodyFields:                     []string{"name"},
-			BodyRequiredFields:             []string{"name"},
-			ForceMultilineRequestCallAsync: true,
-		},
-	}
-
-	syncCode := pygen.RenderOperationMethod(doc, binding, false)
-	if strings.Contains(syncCode, "return self._requester.request(\n") {
-		t.Fatalf("sync request call should not be forced multiline by async-only option:\n%s", syncCode)
-	}
-
-	asyncCode := pygen.RenderOperationMethod(doc, binding, true)
-	if !strings.Contains(asyncCode, "return await self._requester.arequest(\n") {
-		t.Fatalf("async request call should be multiline when async-only option is enabled:\n%s", asyncCode)
-	}
-}
-
 func TestRenderOperationMethodHeadersExpr(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -1296,7 +1296,6 @@ func renderOperationMethodWithContext(
 		callArgs = append(callArgs, item.Expr)
 	}
 	requestExpr := fmt.Sprintf("%s(%s)", requestCall, strings.Join(callArgs, ", "))
-	forceMultilineRequestCall := async && binding.Mapping != nil && binding.Mapping.ForceMultilineRequestCallAsync
 	if binding.Mapping != nil && binding.Mapping.ResponseUnwrapListFirst {
 		buf.WriteString(fmt.Sprintf("        res = %s\n", requestExpr))
 		buf.WriteString("        data = res.data[0]\n")
@@ -1314,15 +1313,7 @@ func renderOperationMethodWithContext(
 			fieldLiterals = append(fieldLiterals, fmt.Sprintf("%q", trimmed))
 		}
 		if async {
-			if forceMultilineRequestCall {
-				buf.WriteString(fmt.Sprintf("        resp: AsyncIteratorHTTPResponse[str] = %s(\n", requestCall))
-				for _, arg := range callArgs {
-					buf.WriteString(fmt.Sprintf("            %s,\n", arg))
-				}
-				buf.WriteString("        )\n")
-			} else {
-				buf.WriteString(fmt.Sprintf("        resp: AsyncIteratorHTTPResponse[str] = %s\n", requestExpr))
-			}
+			buf.WriteString(fmt.Sprintf("        resp: AsyncIteratorHTTPResponse[str] = %s\n", requestExpr))
 			if streamWrapAsyncYield {
 				buf.WriteString("        async for item in AsyncStream(\n")
 				buf.WriteString("            resp.data,\n")
@@ -1348,15 +1339,7 @@ func renderOperationMethodWithContext(
 				buf.WriteString("        )\n")
 			}
 		} else {
-			if forceMultilineRequestCall {
-				buf.WriteString(fmt.Sprintf("        %s: IteratorHTTPResponse[str] = %s(\n", streamWrapSyncResponseVar, requestCall))
-				for _, arg := range callArgs {
-					buf.WriteString(fmt.Sprintf("            %s,\n", arg))
-				}
-				buf.WriteString("        )\n")
-			} else {
-				buf.WriteString(fmt.Sprintf("        %s: IteratorHTTPResponse[str] = %s\n", streamWrapSyncResponseVar, requestExpr))
-			}
+			buf.WriteString(fmt.Sprintf("        %s: IteratorHTTPResponse[str] = %s\n", streamWrapSyncResponseVar, requestExpr))
 			buf.WriteString("        return Stream(\n")
 			buf.WriteString(fmt.Sprintf("            %s._raw_response,\n", streamWrapSyncResponseVar))
 			buf.WriteString(fmt.Sprintf("            %s.data,\n", streamWrapSyncResponseVar))
@@ -1369,15 +1352,7 @@ func renderOperationMethodWithContext(
 			buf.WriteString("        )\n")
 		}
 	} else {
-		if forceMultilineRequestCall {
-			buf.WriteString(fmt.Sprintf("        return %s(\n", requestCall))
-			for _, arg := range callArgs {
-				buf.WriteString(fmt.Sprintf("            %s,\n", arg))
-			}
-			buf.WriteString("        )\n")
-		} else {
-			buf.WriteString(fmt.Sprintf("        return %s\n", requestExpr))
-		}
+		buf.WriteString(fmt.Sprintf("        return %s\n", requestExpr))
 	}
 
 	return buf.String()


### PR DESCRIPTION
## Summary
- remove `force_multiline_request_call` / `force_multiline_request_call_async` config support from `generator.yaml` mapping model
- remove related rendering branches in python operation rendering
- keep default behavior as unified auto formatting for request calls (no force-multiline override)
- delete related test paths and assertions bound to this config

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.1%)
- `./scripts/build.sh`

## Scope Control
- only remove one compatibility config family (`force_multiline_request_call*`)
- no unrelated generator behaviors changed
