### PR TITLE
refactor(py): remove force_multiline_signature_sync config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -199,7 +199,6 @@ type OperationMapping struct {
 	QueryBuilder                   string            `yaml:"query_builder"`
 	BodyFieldValues                map[string]string `yaml:"body_field_values"`
 	HeadersExpr                    string            `yaml:"headers_expr"`
-	ForceMultilineSignatureSync    bool              `yaml:"force_multiline_signature_sync"`
 	ForceMultilineRequestCallAsync bool              `yaml:"force_multiline_request_call_async"`
 	PaginationRequestArg           string            `yaml:"pagination_request_arg"`
 }

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -732,13 +732,6 @@ func renderOperationMethodWithContext(
 		nonKwargsSignatureArgCount++
 	}
 	compactSignature := nonKwargsSignatureArgCount <= 2
-	if binding.Mapping != nil {
-		if !async {
-			if binding.Mapping.ForceMultilineSignatureSync {
-				compactSignature = false
-			}
-		}
-	}
 	if compactSignature {
 		if len(signatureArgs) == 0 {
 			buf.WriteString(fmt.Sprintf("    %s %s(self)%s:\n", methodKeyword, binding.MethodName, returnAnnotation))


### PR DESCRIPTION
## Summary
- remove `force_multiline_signature_sync` config support from codegen
- remove corresponding `OperationMapping` field and Python renderer branch
- default behavior now always follows the signature threshold rule, without a sync-only multiline override

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (total coverage: `83.0%`)
- `./scripts/build.sh`
- `./scripts/gengo.sh --output-sdk exist-repo/coze-go-generated`
- `./scripts/diffgo.sh` (no diff output)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-Yhf2Rq --ci-check` (no pysdk diff)

## Traceability
- downstream `coze-py` PR: https://github.com/coze-dev/coze-py/pull/415
