### PR TITLE
refactor(codegen): remove arg_defaults_sync config support

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4123,8 +4123,10 @@ api:
         document_bases: List[DocumentBase]
         chunk_strategy: Optional[DocumentChunkStrategy]
         format_type: Optional[DocumentFormatType]
-      arg_defaults_sync:
+      arg_defaults:
         format_type: "DocumentFormatType.DOCUMENT"
+      arg_defaults_async:
+        format_type: "None"
       response_type: ListResponse[Document]
       data_field: document_infos
     - path: /open_api/knowledge/document/update

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -173,7 +173,6 @@ type OperationMapping struct {
 	QueryFields                    []OperationField  `yaml:"query_fields"`
 	QueryFieldValues               map[string]string `yaml:"query_field_values"`
 	ArgDefaults                    map[string]string `yaml:"arg_defaults"`
-	ArgDefaultsSync                map[string]string `yaml:"arg_defaults_sync"`
 	ArgDefaultsAsync               map[string]string `yaml:"arg_defaults_async"`
 	Pagination                     string            `yaml:"pagination"`
 	PaginationDataClass            string            `yaml:"pagination_data_class"`

--- a/internal/generator/python/helpers_test.go
+++ b/internal/generator/python/helpers_test.go
@@ -308,10 +308,9 @@ func TestOperationHelpersSignatureAndDefaults(t *testing.T) {
 
 	mapping := &config.OperationMapping{
 		ArgDefaults:      map[string]string{"x": "1"},
-		ArgDefaultsSync:  map[string]string{"x": "2"},
 		ArgDefaultsAsync: map[string]string{"x": "3"},
 	}
-	if got, ok := OperationArgDefault(mapping, "x", "x", false); !ok || got != "2" {
+	if got, ok := OperationArgDefault(mapping, "x", "x", false); !ok || got != "1" {
 		t.Fatalf("OperationArgDefault(sync) got=%q ok=%v", got, ok)
 	}
 	if got, ok := OperationArgDefault(mapping, "x", "x", true); !ok || got != "3" {

--- a/internal/generator/python/operation_helpers.go
+++ b/internal/generator/python/operation_helpers.go
@@ -175,12 +175,9 @@ func OperationArgDefault(mapping *config.OperationMapping, rawName string, argNa
 	if mapping == nil {
 		return "", false
 	}
-	defaultMaps := make([]map[string]string, 0, 3)
+	defaultMaps := make([]map[string]string, 0, 2)
 	if async && len(mapping.ArgDefaultsAsync) > 0 {
 		defaultMaps = append(defaultMaps, mapping.ArgDefaultsAsync)
-	}
-	if !async && len(mapping.ArgDefaultsSync) > 0 {
-		defaultMaps = append(defaultMaps, mapping.ArgDefaultsSync)
 	}
 	if len(mapping.ArgDefaults) > 0 {
 		defaultMaps = append(defaultMaps, mapping.ArgDefaults)


### PR DESCRIPTION
## Summary
- Remove `api.operation_mappings[].arg_defaults_sync` from generator config schema and `config/generator.yaml`.
- Remove sync-only default override branch from Python operation arg-default resolution.
- Define default behavior as:
  - Shared defaults go in `arg_defaults`.
  - Async-specific overrides go in `arg_defaults_async`.
- Migrate existing mapping usage to preserve behavior:
  - `arg_defaults_sync.format_type = DocumentFormatType.DOCUMENT`
  - becomes `arg_defaults.format_type = DocumentFormatType.DOCUMENT`
  - with `arg_defaults_async.format_type = None`.
- Update helper tests for new precedence behavior.

## Non-overlap With Existing Open PRs
- This PR does not overlap with current open config-removal tracks:
  - `force_multiline_request_call`
  - `stream_wrap_compact_sync_return`
  - `response_unwrap_list_first`

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.1%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh` (zero diff)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-qEF1lO --ci-check`
- Main-vs-branch generation isolation check: no `.py` source diff caused by this config-removal change.

## Downstream PR
- coze-py PR: https://github.com/coze-dev/coze-py/pull/416
