### PR TITLE
refactor(py): remove pagination_request_arg config support

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4184,7 +4184,6 @@ api:
           required: true
           default: "10"
       pagination: number
-      pagination_request_arg: json
       pagination_data_class: _PrivateListDocumentsData
       pagination_item_type: Document
       pagination_items_field: document_infos
@@ -4306,7 +4305,6 @@ api:
               stacklevel=2,
           )
       pagination: number
-      pagination_request_arg: json
       pagination_data_class: _PrivateListDocumentsData
       pagination_item_type: Document
       pagination_items_field: document_infos

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,7 +198,6 @@ type OperationMapping struct {
 	HeadersExpr                    string            `yaml:"headers_expr"`
 	ForceMultilineSignatureSync    bool              `yaml:"force_multiline_signature_sync"`
 	ForceMultilineRequestCallAsync bool              `yaml:"force_multiline_request_call_async"`
-	PaginationRequestArg           string            `yaml:"pagination_request_arg"`
 }
 
 type OperationField struct {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -655,7 +655,7 @@ func TestRenderOperationMethodHeadersExpr(t *testing.T) {
 	}
 }
 
-func TestRenderOperationMethodPaginationRequestArg(t *testing.T) {
+func TestRenderOperationMethodPaginationRequestArgInferredFromMethod(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{
 		Path:   "/v1/demo/list",
@@ -673,7 +673,6 @@ func TestRenderOperationMethodPaginationRequestArg(t *testing.T) {
 			PaginationTotalField:    "total",
 			PaginationPageNumField:  "page",
 			PaginationPageSizeField: "size",
-			PaginationRequestArg:    "json",
 			ParamAliases: map[string]string{
 				"page": "page_num",
 				"size": "page_size",

--- a/internal/generator/python/helpers.go
+++ b/internal/generator/python/helpers.go
@@ -112,6 +112,15 @@ func listResponseItemType(returnType string) (string, bool) {
 	return itemType, true
 }
 
+func inferPaginationRequestArg(requestMethod string) string {
+	switch strings.ToLower(strings.TrimSpace(requestMethod)) {
+	case "get", "head", "options":
+		return "params"
+	default:
+		return "json"
+	}
+}
+
 func RequestBodyTypeInfo(doc *openapi.Document, schema *openapi.Schema, body *openapi.RequestBody) (string, bool) {
 	_ = doc
 	_ = schema

--- a/internal/generator/python/helpers_test.go
+++ b/internal/generator/python/helpers_test.go
@@ -165,6 +165,27 @@ func TestInferResponseCast(t *testing.T) {
 	}
 }
 
+func TestInferPaginationRequestArg(t *testing.T) {
+	tests := []struct {
+		method string
+		want   string
+	}{
+		{method: "get", want: "params"},
+		{method: "head", want: "params"},
+		{method: "options", want: "params"},
+		{method: "post", want: "json"},
+		{method: "put", want: "json"},
+		{method: "delete", want: "json"},
+		{method: "", want: "json"},
+	}
+
+	for _, tt := range tests {
+		if got := inferPaginationRequestArg(tt.method); got != tt.want {
+			t.Fatalf("inferPaginationRequestArg(%q) = %q, want %q", tt.method, got, tt.want)
+		}
+	}
+}
+
 func TestCommentAndDocstringHelpers(t *testing.T) {
 	buf := &bytes.Buffer{}
 	AppendIndentedCode(buf, "    x = 1\n    y = 2\n", 1)

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -536,15 +536,13 @@ func renderOperationMethodWithContext(
 		}
 		streamWrapAsyncYield = binding.Mapping.StreamWrapAsyncYield
 		headersExpr = strings.TrimSpace(binding.Mapping.HeadersExpr)
-		if override := strings.TrimSpace(binding.Mapping.PaginationRequestArg); override != "" {
-			paginationRequestArg = override
-		}
 		if len(binding.Mapping.BodyFieldValues) > 0 {
 			for k, v := range binding.Mapping.BodyFieldValues {
 				bodyFieldValues[k] = v
 			}
 		}
 	}
+	paginationRequestArg = inferPaginationRequestArg(requestMethod)
 	returnCast = inferResponseCast(binding.Mapping, returnType, returnCast)
 	if ignoreHeaderParams {
 		details.HeaderParameters = nil


### PR DESCRIPTION
## Summary
- remove `pagination_request_arg` from `OperationMapping` config schema
- infer pagination request payload argument from HTTP method (`params` for GET/HEAD/OPTIONS, otherwise `json`)
- delete now-redundant `pagination_request_arg: json` entries in `config/generator.yaml`
- update generator tests for inferred behavior and helper coverage

## Non-overlap with existing PRs
- verified current open PRs (#50, #51, #52, #36, #35); none removes `pagination_request_arg`

## Validation
- ./scripts/fmt.sh
- ./scripts/lint.sh
- ./scripts/test.sh (Total coverage: 83.0%)
- ./scripts/build.sh
