### PR TITLE
refactor(py): replace arg_defaults_async page_size override with page_size_default

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4762,8 +4762,6 @@ api:
       pagination_total_field: total
       pagination_page_num_field: page_num
       pagination_page_size_field: page_size
-      arg_defaults_async:
-        page_size: "100"
       response_type: NumberPaged[VoicePrintGroup]
       async_response_type: AsyncNumberPaged[VoicePrintGroup]
     - path: /v1/audio/voiceprint_groups/{group_id}/speaker_identify
@@ -4874,8 +4872,6 @@ api:
       pagination_total_field: total
       pagination_page_num_field: page_num
       pagination_page_size_field: page_size
-      arg_defaults_async:
-        page_size: "100"
       response_type: NumberPaged[VoicePrintGroupFeature]
       async_response_type: AsyncNumberPaged[VoicePrintGroupFeature]
     - path: /v1/audio/voices

--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4762,6 +4762,8 @@ api:
       pagination_total_field: total
       pagination_page_num_field: page_num
       pagination_page_size_field: page_size
+      # Keep async page_size=100 for legacy SDK compatibility. Do not remove.
+      page_size_default: "100"
       response_type: NumberPaged[VoicePrintGroup]
       async_response_type: AsyncNumberPaged[VoicePrintGroup]
     - path: /v1/audio/voiceprint_groups/{group_id}/speaker_identify
@@ -4872,6 +4874,8 @@ api:
       pagination_total_field: total
       pagination_page_num_field: page_num
       pagination_page_size_field: page_size
+      # Keep async page_size=100 for legacy SDK compatibility. Do not remove.
+      page_size_default: "100"
       response_type: NumberPaged[VoicePrintGroupFeature]
       async_response_type: AsyncNumberPaged[VoicePrintGroupFeature]
     - path: /v1/audio/voices

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,7 +174,6 @@ type OperationMapping struct {
 	QueryFieldValues         map[string]string `yaml:"query_field_values"`
 	ArgDefaults              map[string]string `yaml:"arg_defaults"`
 	ArgDefaultsSync          map[string]string `yaml:"arg_defaults_sync"`
-	ArgDefaultsAsync         map[string]string `yaml:"arg_defaults_async"`
 	Pagination               string            `yaml:"pagination"`
 	PaginationDataClass      string            `yaml:"pagination_data_class"`
 	PaginationItemType       string            `yaml:"pagination_item_type"`
@@ -192,9 +191,11 @@ type OperationMapping struct {
 	StreamWrap               bool              `yaml:"stream_wrap"`
 	StreamWrapHandler        string            `yaml:"stream_wrap_handler"`
 	StreamWrapFields         []string          `yaml:"stream_wrap_fields"`
+	StreamWrapAsyncYield     bool              `yaml:"stream_wrap_async_yield"`
 	QueryBuilder             string            `yaml:"query_builder"`
 	BodyFieldValues          map[string]string `yaml:"body_field_values"`
 	HeadersExpr              string            `yaml:"headers_expr"`
+	PaginationRequestArg     string            `yaml:"pagination_request_arg"`
 }
 
 type OperationField struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,6 +174,7 @@ type OperationMapping struct {
 	QueryFieldValues         map[string]string `yaml:"query_field_values"`
 	ArgDefaults              map[string]string `yaml:"arg_defaults"`
 	ArgDefaultsSync          map[string]string `yaml:"arg_defaults_sync"`
+	PageSizeDefault          string            `yaml:"page_size_default"`
 	Pagination               string            `yaml:"pagination"`
 	PaginationDataClass      string            `yaml:"pagination_data_class"`
 	PaginationItemType       string            `yaml:"pagination_item_type"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1277,7 +1277,7 @@ func TestLinesFromCommentOverrideKeepsLeadingSpaces(t *testing.T) {
 	}
 }
 
-func TestRenderOperationMethodArgDefaultsUseUnifiedDefault(t *testing.T) {
+func TestRenderOperationMethodPageSizeDefaultAsyncOverride(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{
 		Path:   "/v1/demo",
@@ -1291,6 +1291,7 @@ func TestRenderOperationMethodArgDefaultsUseUnifiedDefault(t *testing.T) {
 			QueryFields: []config.OperationField{
 				{Name: "page_size", Type: "int", Required: true, Default: "10"},
 			},
+			PageSizeDefault: "100",
 		},
 	}
 
@@ -1300,8 +1301,8 @@ func TestRenderOperationMethodArgDefaultsUseUnifiedDefault(t *testing.T) {
 	}
 
 	asyncCode := pygen.RenderOperationMethod(doc, binding, true)
-	if !strings.Contains(asyncCode, "page_size: int = 10") {
-		t.Fatalf("expected async default page_size=10:\n%s", asyncCode)
+	if !strings.Contains(asyncCode, "page_size: int = 100") {
+		t.Fatalf("expected async default page_size=100:\n%s", asyncCode)
 	}
 }
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1277,7 +1277,7 @@ func TestLinesFromCommentOverrideKeepsLeadingSpaces(t *testing.T) {
 	}
 }
 
-func TestRenderOperationMethodArgDefaultsAsyncOverride(t *testing.T) {
+func TestRenderOperationMethodArgDefaultsUseUnifiedDefault(t *testing.T) {
 	doc := mustParseSwagger(t)
 	details := openapi.OperationDetails{
 		Path:   "/v1/demo",
@@ -1291,9 +1291,6 @@ func TestRenderOperationMethodArgDefaultsAsyncOverride(t *testing.T) {
 			QueryFields: []config.OperationField{
 				{Name: "page_size", Type: "int", Required: true, Default: "10"},
 			},
-			ArgDefaultsAsync: map[string]string{
-				"page_size": "100",
-			},
 		},
 	}
 
@@ -1303,8 +1300,8 @@ func TestRenderOperationMethodArgDefaultsAsyncOverride(t *testing.T) {
 	}
 
 	asyncCode := pygen.RenderOperationMethod(doc, binding, true)
-	if !strings.Contains(asyncCode, "page_size: int = 100") {
-		t.Fatalf("expected async override page_size=100:\n%s", asyncCode)
+	if !strings.Contains(asyncCode, "page_size: int = 10") {
+		t.Fatalf("expected async default page_size=10:\n%s", asyncCode)
 	}
 }
 

--- a/internal/generator/python/helpers_test.go
+++ b/internal/generator/python/helpers_test.go
@@ -328,14 +328,21 @@ func TestOperationHelpersSignatureAndDefaults(t *testing.T) {
 	}
 
 	mapping := &config.OperationMapping{
-		ArgDefaults:     map[string]string{"x": "1"},
+		ArgDefaults:     map[string]string{"x": "1", "page_size": "10"},
 		ArgDefaultsSync: map[string]string{"x": "2"},
+		PageSizeDefault: "100",
 	}
 	if got, ok := OperationArgDefault(mapping, "x", "x", false); !ok || got != "2" {
 		t.Fatalf("OperationArgDefault(sync) got=%q ok=%v", got, ok)
 	}
 	if got, ok := OperationArgDefault(mapping, "x", "x", true); !ok || got != "1" {
 		t.Fatalf("OperationArgDefault(async) got=%q ok=%v", got, ok)
+	}
+	if got, ok := OperationArgDefault(mapping, "page_size", "page_size", false); !ok || got != "10" {
+		t.Fatalf("OperationArgDefault(sync page_size) got=%q ok=%v", got, ok)
+	}
+	if got, ok := OperationArgDefault(mapping, "page_size", "page_size", true); !ok || got != "100" {
+		t.Fatalf("OperationArgDefault(async page_size) got=%q ok=%v", got, ok)
 	}
 	if _, ok := OperationArgDefault(nil, "x", "x", false); ok {
 		t.Fatal("OperationArgDefault(nil) expected false")

--- a/internal/generator/python/helpers_test.go
+++ b/internal/generator/python/helpers_test.go
@@ -328,14 +328,13 @@ func TestOperationHelpersSignatureAndDefaults(t *testing.T) {
 	}
 
 	mapping := &config.OperationMapping{
-		ArgDefaults:      map[string]string{"x": "1"},
-		ArgDefaultsSync:  map[string]string{"x": "2"},
-		ArgDefaultsAsync: map[string]string{"x": "3"},
+		ArgDefaults:     map[string]string{"x": "1"},
+		ArgDefaultsSync: map[string]string{"x": "2"},
 	}
 	if got, ok := OperationArgDefault(mapping, "x", "x", false); !ok || got != "2" {
 		t.Fatalf("OperationArgDefault(sync) got=%q ok=%v", got, ok)
 	}
-	if got, ok := OperationArgDefault(mapping, "x", "x", true); !ok || got != "3" {
+	if got, ok := OperationArgDefault(mapping, "x", "x", true); !ok || got != "1" {
 		t.Fatalf("OperationArgDefault(async) got=%q ok=%v", got, ok)
 	}
 	if _, ok := OperationArgDefault(nil, "x", "x", false); ok {

--- a/internal/generator/python/operation_helpers.go
+++ b/internal/generator/python/operation_helpers.go
@@ -175,6 +175,14 @@ func OperationArgDefault(mapping *config.OperationMapping, rawName string, argNa
 	if mapping == nil {
 		return "", false
 	}
+	if async {
+		pageSizeDefault := strings.TrimSpace(mapping.PageSizeDefault)
+		rawNameTrimmed := strings.TrimSpace(rawName)
+		argNameTrimmed := strings.TrimSpace(argName)
+		if pageSizeDefault != "" && (argNameTrimmed == "page_size" || rawNameTrimmed == "page_size") {
+			return pageSizeDefault, true
+		}
+	}
 	defaultMaps := make([]map[string]string, 0, 2)
 	if !async && len(mapping.ArgDefaultsSync) > 0 {
 		defaultMaps = append(defaultMaps, mapping.ArgDefaultsSync)

--- a/internal/generator/python/operation_helpers.go
+++ b/internal/generator/python/operation_helpers.go
@@ -175,10 +175,7 @@ func OperationArgDefault(mapping *config.OperationMapping, rawName string, argNa
 	if mapping == nil {
 		return "", false
 	}
-	defaultMaps := make([]map[string]string, 0, 3)
-	if async && len(mapping.ArgDefaultsAsync) > 0 {
-		defaultMaps = append(defaultMaps, mapping.ArgDefaultsAsync)
-	}
+	defaultMaps := make([]map[string]string, 0, 2)
 	if !async && len(mapping.ArgDefaultsSync) > 0 {
 		defaultMaps = append(defaultMaps, mapping.ArgDefaultsSync)
 	}


### PR DESCRIPTION
## Summary
- remove generic `arg_defaults_async` config support
- introduce dedicated `page_size_default` config for async `page_size` defaults
- keep legacy behavior unchanged for voiceprint async list APIs (`page_size=100`)
- add explicit YAML comment on these mappings: this compatibility default must not be removed casually

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.2%)
- `./scripts/build.sh`
- `./scripts/gengo.sh --output-sdk exist-repo/coze-go-generated`
- `./scripts/diffgo.sh`
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-pagesize-zI6r2k --ci-check`

## Downstream
- coze-py PR: https://github.com/coze-dev/coze-py/pull/417
- note: downstream branch was updated back to baseline behavior, resulting in zero SDK diff
