### PR TITLE
refactor(codegen): remove stream_wrap_async_yield config support

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -5181,7 +5181,6 @@ api:
         - id
         - event
         - data
-      stream_wrap_async_yield: true
       response_type: Stream[WorkflowEvent]
       async_response_type: AsyncIterator[WorkflowEvent]
     - path: /v1/workflow/stream_resume
@@ -5212,7 +5211,6 @@ api:
         - id
         - event
         - data
-      stream_wrap_async_yield: true
       response_type: Stream[WorkflowEvent]
       async_response_type: AsyncIterator[WorkflowEvent]
     - path: /v1/workflows/{workflow_id}/run_histories/{execute_id}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -192,7 +192,6 @@ type OperationMapping struct {
 	StreamWrap               bool              `yaml:"stream_wrap"`
 	StreamWrapHandler        string            `yaml:"stream_wrap_handler"`
 	StreamWrapFields         []string          `yaml:"stream_wrap_fields"`
-	StreamWrapAsyncYield     bool              `yaml:"stream_wrap_async_yield"`
 	QueryBuilder             string            `yaml:"query_builder"`
 	BodyFieldValues          map[string]string `yaml:"body_field_values"`
 	HeadersExpr              string            `yaml:"headers_expr"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -519,16 +519,15 @@ func TestRenderOperationMethodStreamWrapYieldAndSyncVarDefault(t *testing.T) {
 	}
 	binding := pygen.OperationBinding{
 		PackageName: "demo",
-		MethodName:  "stream_call",
+		MethodName:  "resume",
 		Details:     details,
 		Mapping: &config.OperationMapping{
-			RequestStream:        true,
-			ResponseType:         "Stream[DemoEvent]",
-			AsyncResponseType:    "AsyncIterator[DemoEvent]",
-			StreamWrap:           true,
-			StreamWrapHandler:    "handle_demo",
-			StreamWrapFields:     []string{"event", "data"},
-			StreamWrapAsyncYield: true,
+			RequestStream:     true,
+			ResponseType:      "Stream[DemoEvent]",
+			AsyncResponseType: "AsyncIterator[DemoEvent]",
+			StreamWrap:        true,
+			StreamWrapHandler: "handle_demo",
+			StreamWrapFields:  []string{"event", "data"},
 		},
 	}
 

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -534,7 +534,6 @@ func renderOperationMethodWithContext(
 		if len(binding.Mapping.StreamWrapFields) > 0 {
 			streamWrapFields = append(streamWrapFields, binding.Mapping.StreamWrapFields...)
 		}
-		streamWrapAsyncYield = binding.Mapping.StreamWrapAsyncYield
 		headersExpr = strings.TrimSpace(binding.Mapping.HeadersExpr)
 		if len(binding.Mapping.BodyFieldValues) > 0 {
 			for k, v := range binding.Mapping.BodyFieldValues {
@@ -564,8 +563,8 @@ func renderOperationMethodWithContext(
 			autoDelegateExtraArgs = append(autoDelegateExtraArgs, "stream="+streamArg)
 		}
 	}
-	if async && requestStream && streamWrap && !streamWrapAsyncYield && binding.MethodName == "stream" {
-		streamWrapAsyncYield = true
+	if async && requestStream && streamWrap {
+		streamWrapAsyncYield = shouldYieldAsyncWrappedStream(binding.MethodName)
 	}
 	bodyFieldNames := make([]string, 0)
 	bodyFixedValues := map[string]string{}
@@ -1368,6 +1367,15 @@ func autoDelegateTarget(methodName string, classMethodNames map[string]struct{})
 		return ""
 	}
 	return "_create"
+}
+
+func shouldYieldAsyncWrappedStream(methodName string) bool {
+	switch strings.TrimSpace(methodName) {
+	case "stream", "resume":
+		return true
+	default:
+		return false
+	}
 }
 
 func mappingFixedStreamArg(mapping *config.OperationMapping) (string, bool) {


### PR DESCRIPTION
## Summary
- remove `api.operation_mappings[].stream_wrap_async_yield` from generator config schema
- remove existing `stream_wrap_async_yield` entries in `config/generator.yaml`
- switch async stream-wrap yield decision to generator inference (`stream`/`resume` methods yield; others return `AsyncStream`)
- keep current generated behavior for existing mappings by inference, without requiring the config switch

## Non-overlap With Existing Open PRs
- This change does not overlap with current open config-removal tracks:
  - `arg_defaults_sync` (#52)
  - `pagination_request_arg` (#53, #54)
  - unwrap inference track (#36)

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.1%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh` (zero diff)
- `./scripts/genpy.sh --output-sdk exist-repo/coze-py --ci-check`

## Notes
- During validation bootstrap, local baseline repos were prepared under `exist-repo/` per AGENTS instructions.

## Downstream PR
- coze-py PR: https://github.com/coze-dev/coze-py/pull/419
