### PR TITLE
refactor(codegen): remove files_expr config support

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4836,7 +4836,8 @@ api:
         - channel
       files_fields:
         - file
-      files_expr: '{"file": _try_fix_file(file)} if file else {}'
+      files_field_values:
+        file: _try_fix_file(file)
       arg_types:
         group_id: str
         feature_id: str

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -161,7 +161,6 @@ type OperationMapping struct {
 	BodyBuilder              string            `yaml:"body_builder"`
 	FilesFields              []string          `yaml:"files_fields"`
 	FilesFieldValues         map[string]string `yaml:"files_field_values"`
-	FilesExpr                string            `yaml:"files_expr"`
 	FilesBeforeBody          bool              `yaml:"files_before_body"`
 	PreDocstringCode         []string          `yaml:"pre_docstring_code"`
 	PreBodyCode              []string          `yaml:"pre_body_code"`

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -571,7 +571,6 @@ func renderOperationMethodWithContext(
 	bodyFixedValues := map[string]string{}
 	filesFieldNames := make([]string, 0)
 	filesFieldValues := map[string]string{}
-	filesExpr := ""
 	filesBeforeBody := false
 	if binding.Mapping != nil && len(binding.Mapping.BodyFields) > 0 {
 		bodyFieldNames = append(bodyFieldNames, binding.Mapping.BodyFields...)
@@ -590,7 +589,6 @@ func renderOperationMethodWithContext(
 		}
 	}
 	if binding.Mapping != nil {
-		filesExpr = strings.TrimSpace(binding.Mapping.FilesExpr)
 		filesBeforeBody = binding.Mapping.FilesBeforeBody
 	}
 	if !shouldGenerateImplicitRequestBody(details.Method, binding.Mapping, details.RequestBodySchema) {
@@ -1112,10 +1110,6 @@ func renderOperationMethodWithContext(
 	}
 	bodyVarAssign := "body"
 	renderFilesAssignment := func() bool {
-		if filesExpr != "" {
-			buf.WriteString(fmt.Sprintf("        files = %s\n", filesExpr))
-			return true
-		}
 		if len(filesFieldNames) == 0 {
 			return false
 		}
@@ -1126,7 +1120,11 @@ func renderOperationMethodWithContext(
 			if override, ok := filesFieldValues[fieldName]; ok && strings.TrimSpace(override) != "" {
 				valueExpr = strings.TrimSpace(override)
 			}
-			buf.WriteString(fmt.Sprintf("        files = {%q: %s}\n", fieldName, valueExpr))
+			if !bodyRequiredSet[fieldName] {
+				buf.WriteString(fmt.Sprintf("        files = {%q: %s} if %s is not None else {}\n", fieldName, valueExpr, argName))
+			} else {
+				buf.WriteString(fmt.Sprintf("        files = {%q: %s}\n", fieldName, valueExpr))
+			}
 			return true
 		}
 
@@ -1235,7 +1233,6 @@ func renderOperationMethodWithContext(
 		needsBlankLine := len(queryFields) > 0 ||
 			len(bodyFieldNames) > 0 ||
 			len(bodyFixedValues) > 0 ||
-			filesExpr != "" ||
 			len(filesFieldNames) > 0 ||
 			requestBodyType != "" ||
 			strings.EqualFold(requestMethod, "delete") ||
@@ -1284,7 +1281,7 @@ func renderOperationMethodWithContext(
 	if bodyArgExpr != "" {
 		optionalArgs = append(optionalArgs, requestCallArg{Expr: fmt.Sprintf("body=%s", bodyArgExpr)})
 	}
-	if filesExpr != "" || len(filesFieldNames) > 0 {
+	if len(filesFieldNames) > 0 {
 		optionalArgs = append(optionalArgs, requestCallArg{Expr: "files=files"})
 	}
 	if dataField != "" {

--- a/internal/generator/python/request_body_policy.go
+++ b/internal/generator/python/request_body_policy.go
@@ -37,7 +37,7 @@ func hasExplicitPayloadConfig(mapping *config.OperationMapping) bool {
 	if len(mapping.BodyFields) > 0 || len(mapping.BodyFixedValues) > 0 {
 		return true
 	}
-	if len(mapping.FilesFields) > 0 || strings.TrimSpace(mapping.FilesExpr) != "" {
+	if len(mapping.FilesFields) > 0 {
 		return true
 	}
 	return len(mapping.BodyFieldValues) > 0


### PR DESCRIPTION
## Summary
- Remove `api.operation_mappings[].files_expr` from generator config schema and `config/generator.yaml`.
- Remove Python rendering branch that directly injects `files = <expr>` from mapping.
- Define default behavior for single file payload fields:
  - If the field is optional, generate `files = {...} if <arg> is not None else {}`.
  - If required, keep direct dict assignment.
- Migrate existing `audio_voiceprint_groups_features.update` mapping to use `files_field_values.file = _try_fix_file(file)`.
- Add generator test coverage for optional single-file default behavior.

## Non-overlap With Existing Open PRs
- This PR does not overlap with current open config-removal tracks:
  - `arg_defaults_async`
  - `pagination_request_arg`
  - `response_unwrap_list_first`

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.1%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh` (zero diff)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-DfIlej --ci-check`

## Downstream PR
- coze-py PR: https://github.com/coze-dev/coze-py/pull/418
