### PR TITLE
refactor(py): remove leftover force_multiline_signature config

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4680,7 +4680,6 @@ api:
       order: 81
       sdk_methods:
         - audio_transcriptions.create
-      force_multiline_signature: true
       files_fields:
         - file
       files_field_values:
@@ -4694,7 +4693,6 @@ api:
       sdk_methods:
         - audio_live.retrieve
       allow_missing_in_swagger: true
-      force_multiline_signature: true
       response_type: LiveInfo
     - path: /v1/audio/voiceprint_groups
       method: post
@@ -4733,7 +4731,6 @@ api:
       sdk_methods:
         - audio_voiceprint_groups.delete
       allow_missing_in_swagger: true
-      force_multiline_signature: true
       response_type: DeleteVoicePrintGroupResp
     - path: /v1/audio/voiceprint_groups
       method: get
@@ -4855,7 +4852,6 @@ api:
       sdk_methods:
         - audio_voiceprint_groups_features.delete
       allow_missing_in_swagger: true
-      force_multiline_signature: true
       response_type: DeleteVoicePrintGroupFeatureResp
     - path: /v1/audio/voiceprint_groups/{group_id}/features
       method: get
@@ -4983,7 +4979,6 @@ api:
       sdk_methods:
         - conversations_message.delete
       query_builder: raw
-      force_multiline_signature: true
       response_type: Message
     - path: /v1/conversation/message/modify
       method: post
@@ -5008,7 +5003,6 @@ api:
       sdk_methods:
         - conversations_message.retrieve
       query_builder: raw
-      force_multiline_signature: true
       response_type: Message
     - path: /v1/conversations/{conversation_id}/messages/{message_id}/feedback
       method: post


### PR DESCRIPTION
## Summary
- remove leftover `force_multiline_signature` entries from `generator.yaml`
- code support for this config has already been removed in previous merged changes; this PR cleans residual config keys
- default behavior remains unchanged: method signatures follow the threshold rule by default

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (total coverage: `83.1%`)
- `./scripts/build.sh`
- `./scripts/gengo.sh --output-sdk exist-repo/coze-go-generated`
- `./scripts/diffgo.sh` (no diff output)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-eLY4c0 --ci-check` (no pysdk diff)

## Traceability
- downstream `coze-py` PR: https://github.com/coze-dev/coze-py/pull/420
