### PR TITLE
refactor(py): remove arg_defaults_sync config support

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4123,7 +4123,7 @@ api:
         document_bases: List[DocumentBase]
         chunk_strategy: Optional[DocumentChunkStrategy]
         format_type: Optional[DocumentFormatType]
-      arg_defaults_sync:
+      arg_defaults:
         format_type: "DocumentFormatType.DOCUMENT"
       response_type: ListResponse[Document]
       data_field: document_infos

--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4125,6 +4125,8 @@ api:
         format_type: Optional[DocumentFormatType]
       arg_defaults:
         format_type: "DocumentFormatType.DOCUMENT"
+      arg_defaults_async:
+        format_type: "None"
       response_type: ListResponse[Document]
       data_field: document_infos
     - path: /open_api/knowledge/document/update

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -173,7 +173,6 @@ type OperationMapping struct {
 	QueryFields              []OperationField  `yaml:"query_fields"`
 	QueryFieldValues         map[string]string `yaml:"query_field_values"`
 	ArgDefaults              map[string]string `yaml:"arg_defaults"`
-	ArgDefaultsSync          map[string]string `yaml:"arg_defaults_sync"`
 	ArgDefaultsAsync         map[string]string `yaml:"arg_defaults_async"`
 	Pagination               string            `yaml:"pagination"`
 	PaginationDataClass      string            `yaml:"pagination_data_class"`

--- a/internal/generator/python/helpers_test.go
+++ b/internal/generator/python/helpers_test.go
@@ -329,10 +329,9 @@ func TestOperationHelpersSignatureAndDefaults(t *testing.T) {
 
 	mapping := &config.OperationMapping{
 		ArgDefaults:      map[string]string{"x": "1"},
-		ArgDefaultsSync:  map[string]string{"x": "2"},
 		ArgDefaultsAsync: map[string]string{"x": "3"},
 	}
-	if got, ok := OperationArgDefault(mapping, "x", "x", false); !ok || got != "2" {
+	if got, ok := OperationArgDefault(mapping, "x", "x", false); !ok || got != "1" {
 		t.Fatalf("OperationArgDefault(sync) got=%q ok=%v", got, ok)
 	}
 	if got, ok := OperationArgDefault(mapping, "x", "x", true); !ok || got != "3" {

--- a/internal/generator/python/operation_helpers.go
+++ b/internal/generator/python/operation_helpers.go
@@ -175,12 +175,9 @@ func OperationArgDefault(mapping *config.OperationMapping, rawName string, argNa
 	if mapping == nil {
 		return "", false
 	}
-	defaultMaps := make([]map[string]string, 0, 3)
+	defaultMaps := make([]map[string]string, 0, 2)
 	if async && len(mapping.ArgDefaultsAsync) > 0 {
 		defaultMaps = append(defaultMaps, mapping.ArgDefaultsAsync)
-	}
-	if !async && len(mapping.ArgDefaultsSync) > 0 {
-		defaultMaps = append(defaultMaps, mapping.ArgDefaultsSync)
 	}
 	if len(mapping.ArgDefaults) > 0 {
 		defaultMaps = append(defaultMaps, mapping.ArgDefaults)


### PR DESCRIPTION
## Summary
- remove `arg_defaults_sync` from operation mapping config schema
- remove sync-only default resolution from python generator (`OperationArgDefault`)
- convert the previous sync-only usage to shared `arg_defaults`
- add async override in config to preserve existing SDK behavior (`arg_defaults_async.format_type = None`)

## Default behavior after removal
- sync and async share `arg_defaults` by default
- async-only overrides remain available via `arg_defaults_async`

## Validation
- ./scripts/fmt.sh
- ./scripts/lint.sh
- ./scripts/test.sh
- ./scripts/build.sh
- ./scripts/genpy.sh --output-sdk /tmp/coze-py-jWHTYW --ci-check
- ./scripts/gengo.sh --output-sdk exist-repo/coze-go-generated
- ./scripts/diffgo.sh

## Downstream PR
- coze-py: https://github.com/coze-dev/coze-py/pull/422 (no sdk diff)
