### PR TITLE
refactor(py): remove ignore_header_params config support

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4047,7 +4047,7 @@ api:
       body_builder: raw
       body_fields:
         - document_ids
-      ignore_header_params: true
+      headers_expr: kwargs.get("headers")
       response_type: ListResponse[DocumentProgress]
       data_field: data.data
     - path: /v1/connectors/{connector_id}/bots/{bot_id}
@@ -4105,7 +4105,6 @@ api:
       sdk_methods:
         - datasets_documents.create
       body_builder: raw
-      ignore_header_params: true
       headers_expr: '{"Agw-Js-Conv": "str"}'
       body_fields:
         - dataset_id
@@ -4134,7 +4133,6 @@ api:
         - datasets_documents.update
       allow_missing_in_swagger: true
       body_builder: raw
-      ignore_header_params: true
       headers_expr: '{"Agw-Js-Conv": "str"}'
       body_fields:
         - document_id
@@ -4153,7 +4151,6 @@ api:
       sdk_methods:
         - datasets_documents.delete
       body_builder: raw
-      ignore_header_params: true
       headers_expr: '{"Agw-Js-Conv": "str"}'
       body_fields:
         - document_ids
@@ -4166,7 +4163,6 @@ api:
       sdk_methods:
         - datasets_documents.list
       query_builder: raw
-      ignore_header_params: true
       headers_expr: '{"Agw-Js-Conv": "str"}'
       param_aliases:
         page: page_num
@@ -4198,7 +4194,6 @@ api:
       sdk_methods:
         - knowledge_documents.create
       body_builder: raw
-      ignore_header_params: true
       headers_expr: '{"Agw-Js-Conv": "str"}'
       body_fields:
         - dataset_id
@@ -4231,7 +4226,6 @@ api:
         - knowledge_documents.update
       allow_missing_in_swagger: true
       body_builder: raw
-      ignore_header_params: true
       headers_expr: '{"Agw-Js-Conv": "str"}'
       body_fields:
         - document_id
@@ -4258,7 +4252,6 @@ api:
       sdk_methods:
         - knowledge_documents.delete
       body_builder: raw
-      ignore_header_params: true
       headers_expr: '{"Agw-Js-Conv": "str"}'
       body_fields:
         - document_ids
@@ -4279,7 +4272,6 @@ api:
       sdk_methods:
         - knowledge_documents.list
       query_builder: raw
-      ignore_header_params: true
       headers_expr: '{"Agw-Js-Conv": "str"}'
       param_aliases:
         page: page_num

--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4047,7 +4047,6 @@ api:
       body_builder: raw
       body_fields:
         - document_ids
-      headers_expr: kwargs.get("headers")
       response_type: ListResponse[DocumentProgress]
       data_field: data.data
     - path: /v1/connectors/{connector_id}/bots/{bot_id}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -185,7 +185,6 @@ type OperationMapping struct {
 	PaginationPageNumField   string            `yaml:"pagination_page_num_field"`
 	PaginationPageSizeField  string            `yaml:"pagination_page_size_field"`
 	PaginationPageTokenField string            `yaml:"pagination_page_token_field"`
-	IgnoreHeaderParams       bool              `yaml:"ignore_header_params"`
 	DataField                string            `yaml:"data_field"`
 	ResponseUnwrapListFirst  bool              `yaml:"response_unwrap_list_first"`
 	RequestStream            bool              `yaml:"request_stream"`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -453,7 +453,7 @@ func TestRenderOperationMethodAdvancedOptions(t *testing.T) {
 			},
 			BodyFields:         []string{"name"},
 			BodyRequiredFields: []string{"name"},
-			IgnoreHeaderParams: true,
+			HeadersExpr:        "kwargs.get(\"headers\")",
 			RequestStream:      true,
 			DataField:          "data.items",
 		},
@@ -464,7 +464,7 @@ func TestRenderOperationMethodAdvancedOptions(t *testing.T) {
 		t.Fatalf("did not expect explicit headers signature arg:\n%s", code)
 	}
 	if strings.Contains(code, "X-Trace-Id") {
-		t.Fatalf("did not expect header parameter merge when IgnoreHeaderParams=true:\n%s", code)
+		t.Fatalf("did not expect header parameter merge when headers_expr suppresses swagger header args:\n%s", code)
 	}
 	if !strings.Contains(code, "data_field=\"data.items\"") {
 		t.Fatalf("expected data_field in request call:\n%s", code)
@@ -601,10 +601,9 @@ func TestRenderOperationMethodHeadersExpr(t *testing.T) {
 		MethodName:  "create",
 		Details:     details,
 		Mapping: &config.OperationMapping{
-			BodyBuilder:        "raw",
-			BodyFields:         []string{"name"},
-			IgnoreHeaderParams: true,
-			HeadersExpr:        "{\"Agw-Js-Conv\": \"str\"}",
+			BodyBuilder: "raw",
+			BodyFields:  []string{"name"},
+			HeadersExpr: "{\"Agw-Js-Conv\": \"str\"}",
 		},
 	}
 

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -472,7 +472,6 @@ func renderOperationMethodWithContext(
 	paginationMode := ""
 	returnType, returnCast := ReturnTypeInfo(doc, details.ResponseSchema)
 	requestBodyType, bodyRequired := RequestBodyTypeInfo(doc, details.RequestBodySchema, details.RequestBody)
-	ignoreHeaderParams := binding.Mapping != nil && binding.Mapping.IgnoreHeaderParams
 	streamWrap := binding.Mapping != nil && binding.Mapping.StreamWrap
 	streamWrapHandler := ""
 	streamWrapFields := []string{}
@@ -541,11 +540,11 @@ func renderOperationMethodWithContext(
 			}
 		}
 	}
-	paginationRequestArg = inferPaginationRequestArg(requestMethod)
-	returnCast = inferResponseCast(binding.Mapping, returnType, returnCast)
-	if ignoreHeaderParams {
+	if headersExpr != "" {
 		details.HeaderParameters = nil
 	}
+	paginationRequestArg = inferPaginationRequestArg(requestMethod)
+	returnCast = inferResponseCast(binding.Mapping, returnType, returnCast)
 	dataField := ""
 	requestStream := false
 	queryBuilder := "dump_exclude_none"


### PR DESCRIPTION
## Summary
- Remove `api.operation_mappings[].ignore_header_params` from config schema and all generator config mappings.
- Infer header-parameter suppression from `headers_expr`: when `headers_expr` is configured, swagger header params are not added to method signatures.
- Update operation rendering tests to cover the new suppression rule.

## Non-overlap With Existing Open PRs
- This PR is independent from current open config-removal tracks:
  - #55 `arg_defaults_async`
  - #56 `files_expr`

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.2%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh`
- `./scripts/genpy.sh --no-ci-check`

## Downstream PR
- coze-py: https://github.com/coze-dev/coze-py/pull/423
