### PR TITLE
refactor(py): remove files_field_values config support

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4680,8 +4680,6 @@ api:
         - audio_transcriptions.create
       files_fields:
         - file
-      files_field_values:
-        file: _try_fix_file(file)
       arg_types:
         file: FileTypes
       response_type: CreateTranscriptionsResp
@@ -4781,8 +4779,6 @@ api:
         - file
       files_fields:
         - file
-      files_field_values:
-        file: _try_fix_file(file)
       arg_types:
         group_id: str
         file: FileTypes
@@ -4808,8 +4804,6 @@ api:
         - file
       files_fields:
         - file
-      files_field_values:
-        file: _try_fix_file(file)
       arg_types:
         group_id: str
         name: str
@@ -4936,8 +4930,6 @@ api:
         - file
       files_fields:
         - file
-      files_field_values:
-        file: _try_fix_file(file)
       arg_types:
         voice_name: str
         file: FileTypes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,7 +160,6 @@ type OperationMapping struct {
 	BodyFixedValues          map[string]string `yaml:"body_fixed_values"`
 	BodyBuilder              string            `yaml:"body_builder"`
 	FilesFields              []string          `yaml:"files_fields"`
-	FilesFieldValues         map[string]string `yaml:"files_field_values"`
 	FilesExpr                string            `yaml:"files_expr"`
 	FilesBeforeBody          bool              `yaml:"files_before_body"`
 	PreDocstringCode         []string          `yaml:"pre_docstring_code"`
@@ -518,14 +517,6 @@ func (c *Config) Validate() error {
 		for j, fileField := range mapping.FilesFields {
 			if strings.TrimSpace(fileField) == "" {
 				return fmt.Errorf("api.operation_mappings[%d].files_fields[%d] should not be empty", i, j)
-			}
-		}
-		for fieldName, fieldValue := range mapping.FilesFieldValues {
-			if strings.TrimSpace(fieldName) == "" {
-				return fmt.Errorf("api.operation_mappings[%d].files_field_values has empty key", i)
-			}
-			if strings.TrimSpace(fieldValue) == "" {
-				return fmt.Errorf("api.operation_mappings[%d].files_field_values[%q] is empty", i, fieldName)
 			}
 		}
 		for j, codeBlock := range mapping.PreBodyCode {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1330,11 +1330,10 @@ func TestRenderOperationMethodFilesBeforeBody(t *testing.T) {
 		MethodName:  "create",
 		Details:     details,
 		Mapping: &config.OperationMapping{
-			BodyBuilder:      "remove_none_values",
-			BodyFields:       []string{"name"},
-			FilesFields:      []string{"file"},
-			FilesFieldValues: map[string]string{"file": "_try_fix_file(file)"},
-			FilesBeforeBody:  true,
+			BodyBuilder:     "remove_none_values",
+			BodyFields:      []string{"name"},
+			FilesFields:     []string{"file"},
+			FilesBeforeBody: true,
 			ArgTypes: map[string]string{
 				"group_id": "str",
 				"name":     "str",

--- a/internal/generator/python/operation_render.go
+++ b/internal/generator/python/operation_render.go
@@ -569,7 +569,6 @@ func renderOperationMethodWithContext(
 	bodyFieldNames := make([]string, 0)
 	bodyFixedValues := map[string]string{}
 	filesFieldNames := make([]string, 0)
-	filesFieldValues := map[string]string{}
 	filesExpr := ""
 	filesBeforeBody := false
 	if binding.Mapping != nil && len(binding.Mapping.BodyFields) > 0 {
@@ -582,11 +581,6 @@ func renderOperationMethodWithContext(
 	}
 	if binding.Mapping != nil && len(binding.Mapping.FilesFields) > 0 {
 		filesFieldNames = append(filesFieldNames, binding.Mapping.FilesFields...)
-	}
-	if binding.Mapping != nil && len(binding.Mapping.FilesFieldValues) > 0 {
-		for k, v := range binding.Mapping.FilesFieldValues {
-			filesFieldValues[k] = v
-		}
 	}
 	if binding.Mapping != nil {
 		filesExpr = strings.TrimSpace(binding.Mapping.FilesExpr)
@@ -1121,10 +1115,7 @@ func renderOperationMethodWithContext(
 		if len(filesFieldNames) == 1 {
 			fieldName := filesFieldNames[0]
 			argName := OperationArgName(fieldName, paramAliases)
-			valueExpr := argName
-			if override, ok := filesFieldValues[fieldName]; ok && strings.TrimSpace(override) != "" {
-				valueExpr = strings.TrimSpace(override)
-			}
+			valueExpr := fmt.Sprintf("_try_fix_file(%s)", argName)
 			buf.WriteString(fmt.Sprintf("        files = {%q: %s}\n", fieldName, valueExpr))
 			return true
 		}
@@ -1132,10 +1123,7 @@ func renderOperationMethodWithContext(
 		buf.WriteString("        files = {\n")
 		for _, filesField := range filesFieldNames {
 			argName := OperationArgName(filesField, paramAliases)
-			valueExpr := argName
-			if override, ok := filesFieldValues[filesField]; ok && strings.TrimSpace(override) != "" {
-				valueExpr = strings.TrimSpace(override)
-			}
+			valueExpr := fmt.Sprintf("_try_fix_file(%s)", argName)
 			buf.WriteString(fmt.Sprintf("            %q: %s,\n", filesField, valueExpr))
 		}
 		buf.WriteString("        }\n")


### PR DESCRIPTION
## Summary
- Remove `api.operation_mappings[].files_field_values` from config schema and `config/generator.yaml`.
- Keep upload payload behavior by automatically applying `_try_fix_file(...)` for each `files_fields` entry during Python method rendering.
- Preserve existing `files_expr` support and `files_before_body` ordering behavior.
- Update generator tests to cover behavior without `files_field_values`.

## Non-overlap With Existing Open PRs
- This change does not overlap with current open tracks:
  - `files_expr` removal (#56)
  - `arg_defaults_async` removal (#55)
  - `response_unwrap_list_first` inference (#36)

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.2%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh` (zero diff)
