### PR TITLE
refactor(codegen): remove headers_expr config support

### DIFF
--- a/config/generator.yaml
+++ b/config/generator.yaml
@@ -4106,7 +4106,6 @@ api:
         - datasets_documents.create
       body_builder: raw
       ignore_header_params: true
-      headers_expr: '{"Agw-Js-Conv": "str"}'
       body_fields:
         - dataset_id
         - document_bases
@@ -4135,7 +4134,8 @@ api:
       allow_missing_in_swagger: true
       body_builder: raw
       ignore_header_params: true
-      headers_expr: '{"Agw-Js-Conv": "str"}'
+      pre_body_code:
+        - 'headers = {"Agw-Js-Conv": "str"}'
       body_fields:
         - document_id
         - document_name
@@ -4154,7 +4154,6 @@ api:
         - datasets_documents.delete
       body_builder: raw
       ignore_header_params: true
-      headers_expr: '{"Agw-Js-Conv": "str"}'
       body_fields:
         - document_ids
       arg_types:
@@ -4167,7 +4166,6 @@ api:
         - datasets_documents.list
       query_builder: raw
       ignore_header_params: true
-      headers_expr: '{"Agw-Js-Conv": "str"}'
       param_aliases:
         page: page_num
         size: page_size
@@ -4199,7 +4197,6 @@ api:
         - knowledge_documents.create
       body_builder: raw
       ignore_header_params: true
-      headers_expr: '{"Agw-Js-Conv": "str"}'
       body_fields:
         - dataset_id
         - document_bases
@@ -4232,7 +4229,8 @@ api:
       allow_missing_in_swagger: true
       body_builder: raw
       ignore_header_params: true
-      headers_expr: '{"Agw-Js-Conv": "str"}'
+      pre_body_code:
+        - 'headers = {"Agw-Js-Conv": "str"}'
       body_fields:
         - document_id
         - document_name
@@ -4259,7 +4257,6 @@ api:
         - knowledge_documents.delete
       body_builder: raw
       ignore_header_params: true
-      headers_expr: '{"Agw-Js-Conv": "str"}'
       body_fields:
         - document_ids
       arg_types:
@@ -4280,7 +4277,6 @@ api:
         - knowledge_documents.list
       query_builder: raw
       ignore_header_params: true
-      headers_expr: '{"Agw-Js-Conv": "str"}'
       param_aliases:
         page: page_num
         size: page_size

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -194,7 +194,6 @@ type OperationMapping struct {
 	StreamWrapFields         []string          `yaml:"stream_wrap_fields"`
 	QueryBuilder             string            `yaml:"query_builder"`
 	BodyFieldValues          map[string]string `yaml:"body_field_values"`
-	HeadersExpr              string            `yaml:"headers_expr"`
 }
 
 type OperationField struct {


### PR DESCRIPTION
## Summary
- remove `api.operation_mappings[].headers_expr` from config schema and `config/generator.yaml`
- infer fixed headers from Swagger when `ignore_header_params=true` for `/open_api/knowledge/document/*` and the header is required with a single enum value
- keep compatibility for the two `allow_missing_in_swagger` update mappings by using `pre_body_code` fixed headers
- avoid duplicate headers assignment when `pre_body_code` already assigns `headers`
- replace the old `headers_expr` rendering test with inference-based tests and add helper coverage

## Non-overlap With Existing Open PRs
- no overlap with current open config-removal PRs:
  - #55 `arg_defaults_async`
  - #56 `files_expr`

## Validation
- `./scripts/fmt.sh`
- `./scripts/lint.sh`
- `./scripts/test.sh` (Total coverage: 83.2%)
- `./scripts/build.sh`
- `./scripts/gengo.sh`
- `./scripts/diffgo.sh` (zero diff)
- `./scripts/genpy.sh --output-sdk /tmp/coze-py-DMdifD --ci-check`
- generated `/tmp/coze-py-DMdifD` diff file count: 0
